### PR TITLE
Create Readmw.txt file and pack it to nuget package

### DIFF
--- a/Integration/Olive.ApiProxyGenerator/Olive.ApiProxyGenerator.csproj
+++ b/Integration/Olive.ApiProxyGenerator/Olive.ApiProxyGenerator.csproj
@@ -7,6 +7,14 @@
     <ApplicationIcon />
     <AssemblyName>Olive.ApiProxyGenerator</AssemblyName>
     <RootNamespace>Olive.ApiProxy</RootNamespace>
+    <Authors>Geeks Ltd</Authors>
+    <Company>Geeks Ltd.</Company>
+    <Version>1.0.61</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageProjectUrl>https://github.com/Geeksltd/Olive/blob/master/Integration/Olive.Microservices/Integration.md</PackageProjectUrl>
+    <Copyright>Copyright ©2018 Geeks Ltd - All rights reserved.</Copyright>
+    <Description>Generates Api Proxy packages for Olive microservice Apis</Description>
+    <PackageIconUrl>http://licensing.msharp.co.uk/Images/OliveComponent.png</PackageIconUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -29,5 +37,12 @@
       <HintPath>..\..\@Assemblies\netcoreapp2.0\Olive.Mvc.dll</HintPath>
     </Reference>
   </ItemGroup>
-
+  
+  <ItemGroup>
+    <Content Include="README.txt">
+      <Pack>true</Pack>
+      <PackagePath>README.txt</PackagePath>
+    </Content>
+  </ItemGroup>
+  
 </Project>

--- a/Integration/Olive.ApiProxyGenerator/Package.nuspec
+++ b/Integration/Olive.ApiProxyGenerator/Package.nuspec
@@ -14,6 +14,7 @@
     </dependencies>
   </metadata>
   <files>
+    <file src="README.txt" target="" />
     <file src="bin\Debug\netcoreapp2.0\Olive.ApiProxyGenerator.dll" target="lib\netcoreapp2.0\" />
     <file src="bin\Debug\netcoreapp2.0\Olive.ApiProxyGenerator.runtimeconfig.json" target="lib\netcoreapp2.0\" />
   </files>

--- a/Integration/Olive.ApiProxyGenerator/Project/ProjectCreator.cs
+++ b/Integration/Olive.ApiProxyGenerator/Project/ProjectCreator.cs
@@ -47,6 +47,16 @@ namespace Olive.ApiProxy
             content.Insert(content.IndexOf(x => x.Trim().StartsWith("<TargetFramework")) + 1,
                 $@"    <DocumentationFile>bin\Debug\{Framework}\{Context.ControllerName}.{Name}.xml</DocumentationFile>"
                 );
+            var ItemGroup = @"
+  <ItemGroup>
+    <Content Include=""README.txt"">
+      <Pack>true</Pack>
+      <PackagePath>README.txt</PackagePath>
+    </Content>
+  </ItemGroup>".Split('\r', '\n');
+            var indexOf = content.IndexOf(x => x.Trim().StartsWith("</Project>"));
+            content.InsertRange(indexOf, ItemGroup);
+
             file.WriteAllText(content.ToLinesString());
         }
 
@@ -106,6 +116,7 @@ namespace Olive.ApiProxy
     <description>Provides an easy method to invoke the Api functions of {Context.ControllerName}</description>
   </metadata>
   <files>
+    <file src=""README.txt"" target="""" />
     <file src=""{dll}.dll"" target=""lib\{Framework}\"" />
     {xml}
   </files>

--- a/Integration/Olive.ApiProxyGenerator/Project/ProxyProjectCreator.cs
+++ b/Integration/Olive.ApiProxyGenerator/Project/ProxyProjectCreator.cs
@@ -19,6 +19,10 @@ namespace Olive.ApiProxy
             Folder.GetFile($"{Context.ControllerName}.cs").WriteAllText(ProxyClassProgrammer.Generate());
             Console.WriteLine("Done");
 
+            Console.Write("Adding ReamMe.txt file ...");
+            Folder.GetFile($"README.txt").WriteAllText(ReadmeFileGenerator.Generate());
+            Console.WriteLine("Done");
+
             GenerateDtoClasses();
             GenerateDataProviderClasses();
         }

--- a/Integration/Olive.ApiProxyGenerator/README.txt
+++ b/Integration/Olive.ApiProxyGenerator/README.txt
@@ -1,0 +1,11 @@
+﻿
+Sample Readme Content ...
+
+Owners
+GeeksLtd
+
+Authors
+Geeks Ltd
+
+Copyright
+Copyright ©2018 Geeks Ltd - All rights reserved.

--- a/Integration/Olive.ApiProxyGenerator/ReadmeFileGenerator.cs
+++ b/Integration/Olive.ApiProxyGenerator/ReadmeFileGenerator.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Olive.ApiProxy
+{
+    internal class ReadmeFileGenerator
+    {
+        internal static string Generate()
+        {
+            var content = @"
+Sample Readme Content ...
+
+Owners
+GeeksLtd
+
+Authors
+Geeks Ltd
+
+Copyright
+Copyright ©2018 Geeks Ltd - All rights reserved.";
+            return content;
+        }
+
+    }
+}


### PR DESCRIPTION
dotnetcore Apps have some problem to pack readme.txt file as file content in package ,so best way to include readme.txt file in nuget package is using "dotnet pack " , (all developers suggest this way ,until nuget.exe update this issue ), but in olive project ,package are create with nuget.exe command , so we should change the package creation routine.