### PR TITLE
Updated all projects of type Olive.* to use the update-local-nuget-cache command

### DIFF
--- a/Entities/Olive.Entities.Cache.Redis/Olive.Entities.Cache.Redis.csproj
+++ b/Entities/Olive.Entities.Cache.Redis/Olive.Entities.Cache.Redis.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell start-process dotnet &quot;$(TargetDir)PushForLocalTesting.dll&quot;" />
+    <Exec Command="powershell start-process dotnet &quot;$(TargetDir)PushForLocalTesting.dll&quot;&#xD;&#xA;update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
   </Target>
 
 </Project>

--- a/Integration/Olive.ApiClient/Olive.ApiClient.csproj
+++ b/Integration/Olive.ApiClient/Olive.ApiClient.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell start-process &quot;$(TargetDir)..\PublishToLocalNuget.exe&quot;" />
+    <Exec Command="powershell start-process &quot;$(TargetDir)..\PublishToLocalNuget.exe&quot;&#xD;&#xA;update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
   </Target>
 
 </Project>

--- a/Integration/Olive.ApiProxyGenerator/Olive.ApiProxyGenerator.csproj
+++ b/Integration/Olive.ApiProxyGenerator/Olive.ApiProxyGenerator.csproj
@@ -33,5 +33,9 @@
       <HintPath>..\..\@Assemblies\netcoreapp2.1\Olive.Mvc.dll</HintPath>
     </Reference>
   </ItemGroup>
+  
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
 
 </Project>

--- a/Integration/Olive.Microservices/Olive.Microservices.csproj
+++ b/Integration/Olive.Microservices/Olive.Microservices.csproj
@@ -28,4 +28,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Mvc/Olive.Email/Olive.Email.csproj
+++ b/Mvc/Olive.Email/Olive.Email.csproj
@@ -34,4 +34,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Mvc/Olive.Hangfire/Olive.Hangfire.csproj
+++ b/Mvc/Olive.Hangfire/Olive.Hangfire.csproj
@@ -32,4 +32,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Mvc/Olive.Mvc.Globalization/Olive.Globalization.csproj
+++ b/Mvc/Olive.Mvc.Globalization/Olive.Globalization.csproj
@@ -29,4 +29,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Mvc/Olive.Mvc.Paging/Olive.Mvc.Paging.csproj
+++ b/Mvc/Olive.Mvc.Paging/Olive.Mvc.Paging.csproj
@@ -36,4 +36,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Mvc/Olive.Mvc.Security.Auth0/Olive.Security.Auth0.csproj
+++ b/Mvc/Olive.Mvc.Security.Auth0/Olive.Security.Auth0.csproj
@@ -25,4 +25,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Mvc/Olive.Mvc.Testing/Olive.Mvc.Testing.csproj
+++ b/Mvc/Olive.Mvc.Testing/Olive.Mvc.Testing.csproj
@@ -48,4 +48,8 @@
     <Folder Include="Contracts\" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Mvc/Olive.Security.Aws/Olive.Security.Aws.csproj
+++ b/Mvc/Olive.Security.Aws/Olive.Security.Aws.csproj
@@ -39,4 +39,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Mvc/Olive.Security.Impersonation/Olive.Security.Impersonation.csproj
+++ b/Mvc/Olive.Security.Impersonation/Olive.Security.Impersonation.csproj
@@ -40,4 +40,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Mvc/Olive.Security/Olive.Mvc.Security.csproj
+++ b/Mvc/Olive.Security/Olive.Mvc.Security.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell start-process dotnet &quot;$(TargetDir)PushForLocalTesting.dll&quot;" />
+    <Exec Command="powershell start-process dotnet &quot;$(TargetDir)PushForLocalTesting.dll&quot;&#xD;&#xA;update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
   </Target>
 
 </Project>

--- a/Mvc/Olive.Web/Olive.Web.csproj
+++ b/Mvc/Olive.Web/Olive.Web.csproj
@@ -30,4 +30,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Olive.Audit.DatabaseLogger/Olive.Audit.DatabaseLogger.csproj
+++ b/Olive.Audit.DatabaseLogger/Olive.Audit.DatabaseLogger.csproj
@@ -29,4 +29,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Olive.Audit/Olive.Audit.csproj
+++ b/Olive.Audit/Olive.Audit.csproj
@@ -26,4 +26,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Olive.Aws.Ses/Olive.Aws.Ses.csproj
+++ b/Olive.Aws.Ses/Olive.Aws.Ses.csproj
@@ -28,5 +28,8 @@
       <HintPath>..\@Assemblies\netcoreapp2.1\Olive.Email.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
 
 </Project>

--- a/Olive.Entities.Data.MySql/Olive.Entities.Data.MySql.csproj
+++ b/Olive.Entities.Data.MySql/Olive.Entities.Data.MySql.csproj
@@ -34,4 +34,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Olive.Entities.Data.PostgreSQL/Olive.Entities.Data.PostgreSQL.csproj
+++ b/Olive.Entities.Data.PostgreSQL/Olive.Entities.Data.PostgreSQL.csproj
@@ -29,4 +29,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Olive.Entities.Data.SQLite/Olive.Entities.Data.SQLite.csproj
+++ b/Olive.Entities.Data.SQLite/Olive.Entities.Data.SQLite.csproj
@@ -29,4 +29,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Olive.Entities.Data.SqlServer/Olive.Entities.Data.SqlServer.csproj
+++ b/Olive.Entities.Data.SqlServer/Olive.Entities.Data.SqlServer.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell start-process dotnet &quot;$(TargetDir)PushForLocalTesting.dll&quot;" />
+    <Exec Command="powershell start-process dotnet &quot;$(TargetDir)PushForLocalTesting.dll&quot;&#xD;&#xA;update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
   </Target>
 
 </Project>

--- a/Olive.Entities.Data/Olive.Entities.Data.csproj
+++ b/Olive.Entities.Data/Olive.Entities.Data.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
   
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell start-process dotnet &quot;$(TargetDir)PushForLocalTesting.dll&quot;" />
+    <Exec Command="powershell start-process dotnet &quot;$(TargetDir)PushForLocalTesting.dll&quot;&#xD;&#xA;update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
   </Target>
 
 </Project>

--- a/Olive.Entities/Olive.Entities.csproj
+++ b/Olive.Entities/Olive.Entities.csproj
@@ -34,4 +34,8 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Olive/Olive.csproj
+++ b/Olive/Olive.csproj
@@ -7,6 +7,10 @@
     <NoWarn>1701;1702;1705;1591;1573;NU1701</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="GCop.All.Geeks" Version="2.3.9" />
     <PackageReference Include="GCop.UAT" Version="1.3.7" />
@@ -18,7 +22,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell start-process &quot;$(TargetDir)..\PublishToLocalNuget.exe&quot;" />
+    <Exec Command="powershell start-process &quot;$(TargetDir)..\PublishToLocalNuget.exe&quot;&#xD;&#xA;update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
   </Target>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 # Olive
 
-Olive is a framework built top of .NET for more productive cross platform software development in .NET solutions. It provides a whole set of productivity tools to make .NET development easier, cleaner and more expressive. It's available under the GPLv3 license.
+Olive is a framework built on top of .NET for more productive cross platform software development in .NET solutions. It provides a whole set of productivity tools to make .NET development easier, cleaner and more expressive. It's available under the GPLv3 license.
 Olive is a .NET Standard 2.0 library and so compatible with .NET Framework 4.6.1, .NET Core 2.0, Mono 5.4, Xamarin.iOS 10.14, Xamarin.Mac 3.8, Xamarin.Android 7.5 and UWP.
 You can check out Olive documentation [HERE](geeksltd.github.com/Olive)
 
@@ -32,6 +32,7 @@ We'll review your code ASAP and we will do the merge if everything was just fine
 1. Windows 10
 2. Visual Studio 2017 (latest build) with .NET Core and web development features installed.
 3. GIT for Windows ([install from here](http://gitforwindows.org/))
+4. Add GCop package repository to your NuGet sources [link]http://nuget.gcop.co/nuget()
 
 #### Next steps
 

--- a/Services/Olive.Aws/Olive.Aws.csproj
+++ b/Services/Olive.Aws/Olive.Aws.csproj
@@ -28,4 +28,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Services/Olive.Blob.Aws/Olive.BlobAws.csproj
+++ b/Services/Olive.Blob.Aws/Olive.BlobAws.csproj
@@ -33,4 +33,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Services/Olive.CSV/Olive.Csv.csproj
+++ b/Services/Olive.CSV/Olive.Csv.csproj
@@ -28,4 +28,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Services/Olive.Compression/Olive.Compression.csproj
+++ b/Services/Olive.Compression/Olive.Compression.csproj
@@ -25,4 +25,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Services/Olive.Csv/Olive.Csv.csproj
+++ b/Services/Olive.Csv/Olive.Csv.csproj
@@ -28,4 +28,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Services/Olive.Drawing/Olive.Drawing.csproj
+++ b/Services/Olive.Drawing/Olive.Drawing.csproj
@@ -29,4 +29,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Services/Olive.Encryption/Olive.Encryption.csproj
+++ b/Services/Olive.Encryption/Olive.Encryption.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="powershell start-process dotnet &quot;$(TargetDir)PushForLocalTesting.dll&quot;" />
+    <Exec Command="powershell start-process dotnet &quot;$(TargetDir)PushForLocalTesting.dll&quot;&#xD;&#xA;update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
   </Target>
 
 </Project>

--- a/Services/Olive.Excel/Olive.Export.csproj
+++ b/Services/Olive.Excel/Olive.Export.csproj
@@ -30,4 +30,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Services/Olive.GeoLocation/Olive.GeoLocation.csproj
+++ b/Services/Olive.GeoLocation/Olive.GeoLocation.csproj
@@ -24,4 +24,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Services/Olive.PDF/Olive.PDF.csproj
+++ b/Services/Olive.PDF/Olive.PDF.csproj
@@ -26,4 +26,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Services/Olive.PushNotification/Olive.PushNotification.csproj
+++ b/Services/Olive.PushNotification/Olive.PushNotification.csproj
@@ -25,4 +25,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>

--- a/Services/Olive.SMS/Olive.SMS.csproj
+++ b/Services/Olive.SMS/Olive.SMS.csproj
@@ -28,4 +28,8 @@
     </Reference>
   </ItemGroup>
 
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
updated all project files of type Olive.* to use Update-local-nuget-cache command to automatically update your NuGet cache.

It makes development of packages easier by replacing DLLs in the NuGet cache of the user.

- Updated the readme file to be more complete as well. It now describes that one needs to add GCop repo path to its sources in order to be able to build