### PR TITLE
Made API-proxy-generator a tool

### DIFF
--- a/Integration/Olive.ApiProxyGenerator/Olive.ApiProxyGenerator.csproj
+++ b/Integration/Olive.ApiProxyGenerator/Olive.ApiProxyGenerator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -15,7 +15,9 @@
     <PackageIconUrl>http://licensing.msharp.co.uk/Images/OliveComponent.png</PackageIconUrl>
     <Copyright>Copyright ©2018 Geeks Ltd - All rights reserved.</Copyright>
     <Description>Generates Api Proxy packages for Olive microservice Apis</Description>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>    
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>generate-api-proxies</ToolCommandName>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -45,6 +47,10 @@
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="update-local-nuget-cache $(ProjectPath) $(TargetPath) $(TargetName)" />
+  </Target>
+
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <Exec Command="	" />
   </Target>
 
 </Project>


### PR DESCRIPTION
`dotnet generate-api-proxies` is the command
Just added two elements to the csproj file
rest is fine, the console app arguments should be sent after the dotnet generate-api-proxies command