### PR TITLE
fix concurrency bug for IoEventBus

### DIFF
--- a/Olive.EventBus/IOQueue/IOSubscriber.cs
+++ b/Olive.EventBus/IOQueue/IOSubscriber.cs
@@ -31,13 +31,25 @@ namespace Olive
             watcher.EnableRaisingEvents = true;
         }
 
+        static async Task<string> ReadFile(FileInfo item)
+        {
+            while (true)
+                try
+                {
+                    return await item.ReadAllTextAsync();
+                }
+                catch (System.IO.IOException)
+                {
+                }
+        }
+
         internal static async Task<KeyValuePair<FileInfo, TMessage>> FetchOnce(DirectoryInfo folder)
         {
             var item = folder.GetFiles().OrderBy("CreationTimeUtc").FirstOrDefault();
 
             if (item == null) return new KeyValuePair<FileInfo, TMessage>(null, default(TMessage));
 
-            var content = await item.ReadAllTextAsync();
+            var content = await ReadFile(item);
             try
             {
                 var @event = JsonConvert.DeserializeObject<TMessage>(content);

--- a/Olive.EventBus/IOQueue/IoEventBusQueue.cs
+++ b/Olive.EventBus/IOQueue/IoEventBusQueue.cs
@@ -22,10 +22,11 @@ namespace Olive
 
         public async Task<string> Publish(IEventBusMessage message)
         {
+            FileInfo path;
             using (await SyncLock.Lock())
-                await Task.Delay(5.Milliseconds()); // Ensure the file names are unique.
-
-            var path = Folder.GetFile(DateTime.UtcNow.Ticks.ToString());
+            {
+                path = Folder.GetFile(DateTime.UtcNow.Ticks.ToString());
+            }
             await path.WriteAllTextAsync(JsonConvert.SerializeObject(message));
             return path.Name;
         }


### PR DESCRIPTION
There is concurrency when it is publishing message. Two separate messages take same file name.