### PR TITLE
Add content type to the S3 upload request.

### DIFF
--- a/Olive.Blob.Aws/S3BlobStorageProvider.cs
+++ b/Olive.Blob.Aws/S3BlobStorageProvider.cs
@@ -194,6 +194,7 @@ namespace Olive.BlobAws
         {
             return new PutObjectRequest
             {
+                ContentType = document.GetMimeType(),
                 BucketName = AWSInfo.S3BucketName,
                 Key = document.GetKey(),
                 InputStream = new MemoryStream(await document.GetFileDataAsync())


### PR DESCRIPTION
Hey my fellow Geeks,

Recently I noticed that when we're using S3 for serving website's static content, the S3 bucket returns the mime type of SVG file as text! So on this commit I added the content type to the upload request. Hopefully this will resolve the issue.

Please review and let me know what you think about this change.

Have a good one.