### PR TITLE
Add nullable property type support for dynamodb.

### DIFF
--- a/Olive.Entities.Data.DynamoDB/DynamoDBDataProvider.UpdatePropertyData.cs
+++ b/Olive.Entities.Data.DynamoDB/DynamoDBDataProvider.UpdatePropertyData.cs
@@ -30,14 +30,18 @@ namespace Olive.Entities.Data
 
             public static UpdatePropertyData FromProperty(PropertyInfo prop, object owner)
             {
+                var propertyType = prop.PropertyType;
+                if (propertyType.IsNullable())
+                    propertyType = propertyType.GetGenericArguments()[0];
+
                 return new UpdatePropertyData
                 {
                     Name = prop.Name,
                     Value = prop.GetValue(owner),
-                    IsString = prop.PropertyType == typeof(string),
-                    IsBool = prop.PropertyType == typeof(bool),
-                    IsNumber = prop.PropertyType.IsBasicNumeric(),
-                    IsDateTime = prop.PropertyType == typeof(DateTime),
+                    IsString = propertyType == typeof(string),
+                    IsBool = propertyType == typeof(bool),
+                    IsNumber = propertyType.IsBasicNumeric(),
+                    IsDateTime = propertyType == typeof(DateTime),
                     CanRead = prop.CanRead,
                     CanWrite = prop.CanWrite,
                     CustomAttributes = prop.CustomAttributes.ToArray(),


### PR DESCRIPTION
The DynamoDb provider wasn't able to predict `Nullalbe<T>` types. For example it was saving a `DateTime?` property like `17/03/2022 00:00:00`, (default one) which calls 
```c#
Value.ToStringOrEmpty()
```
not
 ```c#
 ((DateTime)Value).ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'")
```
----
The ERROR:
```
System.InvalidOperationException: Unable to convert [17/03/2022 00:00:00] of type Amazon.DynamoDBv2.DocumentModel.Primitive to System.Nullable`1[[System.DateTime, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
   at Amazon.DynamoDBv2.Converter.FromEntry(DynamoDBEntry entry, Type targetType)
   at Amazon.DynamoDBv2.DynamoDBEntryConversion.ConvertFromEntry(Type outputType, DynamoDBEntry entry)
   at Amazon.DynamoDBv2.DataModel.DynamoDBContext.FromDynamoDBEntry(SimplePropertyStorage propertyStorage, DynamoDBEntry entry, DynamoDBFlatConfig flatConfig)
   at Amazon.DynamoDBv2.DataModel.DynamoDBContext.PopulateInstance(ItemStorage storage, Object instance, DynamoDBFlatConfig flatConfig)
   at Amazon.DynamoDBv2.DataModel.DynamoDBContext.DocumentToObject(Type objectType, ItemStorage storage, DynamoDBFlatConfig flatConfig)
   at Amazon.DynamoDBv2.DataModel.DynamoDBContext.DocumentToObject[T](ItemStorage storage, DynamoDBFlatConfig flatConfig)
   at Amazon.DynamoDBv2.DataModel.DynamoDBContext.FromDocumentHelper[T](Document document, DynamoDBFlatConfig flatConfig)
   at Amazon.DynamoDBv2.DataModel.DynamoDBContext.FromDocumentsHelper[T](IEnumerable`1 documents, DynamoDBFlatConfig flatConfig)+MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Amazon.DynamoDBv2.DataModel.AsyncSearch`1.GetRemainingAsync(CancellationToken cancellationToken)
   at Olive.Entities.Data.DynamoDBDataProvider`1.FindByConditions(IDatabaseQuery query)
   at Olive.Entities.Data.DynamoDBDataProvider`1.GetList(IDatabaseQuery query)
   at Olive.OliveExtensions.Get[TSource,TResult](Task`1 this, Func`2 expression)
   at Olive.Entities.Data.DatabaseQuery.LoadFromDatabase()
   at Olive.Entities.Data.DatabaseQuery.LoadFromDatabaseAndCache()
   at Olive.Entities.Data.DatabaseQuery.GetList()
   at Olive.Entities.Data.DatabaseQuery`1.GetList()
   at Controllers.SomethingController.GetSource(SomethingList info, Boolean all) in C:\Projects\**\Website\Controllers\Pages\SomethingController.cs:line 70
   *
```