### PR TITLE
Added decimal to the list of primitive types supported by ToString()

### DIFF
--- a/Olive.Entities/Entity.cs
+++ b/Olive.Entities/Entity.cs
@@ -139,7 +139,7 @@ namespace Olive.Entities
         static PropertyInfo[] ExtractPrimitiveProperties(Type type)
         {
             var result = new List<PropertyInfo>();
-            var primitiveTypes = new[] { typeof(string), typeof(int), typeof(int?), typeof(double), typeof(double?), typeof(DateTime), typeof(DateTime?) };
+            var primitiveTypes = new[] { typeof(string), typeof(int), typeof(int?), typeof(double), typeof(double?), typeof(decimal), typeof(decimal?), typeof(DateTime), typeof(DateTime?) };
 
             foreach (var p in type.GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(p => p.CanRead).Where(p => primitiveTypes.Contains(p.PropertyType)))
             {


### PR DESCRIPTION
Currently, ToString("F"), which is being used in GeneralSearch.AllFields, is accepting primitive types of string, double, and DateTime only. Any other fields would not be part of the GeneralSearch.

Added code to allow decimal to be part of this as well, and in turn be part of Search.

NOTE; Double.ToString() will round off decimal places if they're 0(i.e., 1.00 will be "1", 2.00 will be "2") so double as a workaround does not work, if you use the search term "1.00".

Cheers,
JGS