### PR TITLE
Add TrustedRaw methods for trusted HTML rendering

### DIFF
--- a/Olive.Mvc/Extentions/Extensions.cs
+++ b/Olive.Mvc/Extentions/Extensions.cs
@@ -119,6 +119,11 @@ namespace Olive.Mvc
         /// Will convert this html string into a HtmlString for rendering.
         /// When sanitize is true (default), HTML is cleaned with the shared policy
         /// (see <see cref="HtmlSanitizerFactory"/>) before display.
+        /// <para>
+        /// If you want to ignore the sanitizer, do not pass false here. Call
+        /// <see cref="TrustedRaw(string)"/> instead: it does the same thing, but the name says
+        /// at the call site that the HTML is trusted, which makes a security review much easier.
+        /// </para>
         /// </summary>
         public static HtmlString Raw(this string @this, bool sanitize = true)
         {
@@ -130,9 +135,29 @@ namespace Olive.Mvc
         /// <summary>
         /// Will convert this html string into a HtmlString for rendering.
         /// When sanitize is true (default), HTML is cleaned with HtmlSanitizer before display.
+        /// <para>
+        /// If you want to ignore the sanitizer, do not pass false here. Call
+        /// <see cref="TrustedRaw(Task{string})"/> instead, so the call site says that the
+        /// HTML is trusted.
+        /// </para>
         /// </summary>
         public static Task<HtmlString> Raw(this Task<string> @this, bool sanitize = true) =>
             @this.Get(v => v.Raw(sanitize));
+
+        /// <summary>
+        /// Will convert this html string into a HtmlString for rendering, WITHOUT sanitizing it.
+        /// Only use this for HTML you trust, for example something an admin wrote, or markup your
+        /// own code built. Never use it for text that came from a user or from another system:
+        /// that would open the page to XSS.
+        /// </summary>
+        public static HtmlString TrustedRaw(this string @this) => @this.Raw(sanitize: false);
+
+        /// <summary>
+        /// Will convert this html string into a HtmlString for rendering, WITHOUT sanitizing it.
+        /// Only use this for HTML you trust. See <see cref="TrustedRaw(string)"/>.
+        /// </summary>
+        public static Task<HtmlString> TrustedRaw(this Task<string> @this) =>
+            @this.Get(v => v.TrustedRaw());
 
         /// <summary>
         /// Gets access to the current ViewBag.

--- a/Olive.Mvc/Olive.Mvc.csproj
+++ b/Olive.Mvc/Olive.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.1.0</Version>
+    <Version>10.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Olive.Tests/HtmlSanitizerTests.cs
+++ b/Tests/Olive.Tests/HtmlSanitizerTests.cs
@@ -335,6 +335,31 @@ namespace Olive.Tests
             result.ShouldEqual(input);
         }
 
+        // ---- TrustedRaw: the named way to say "this HTML is trusted, do not clean it" ----
+
+        [Test]
+        public void TrustedRaw_PreservesUnsafeHtml()
+        {
+            var input = "<p onclick=\"evil()\">unsafe</p><script>alert(1)</script>";
+
+            GetHtml(input.TrustedRaw()).ShouldEqual(input);
+        }
+
+        [Test]
+        public void TrustedRaw_NullOrEmpty_ReturnsEmptyHtmlString()
+        {
+            GetHtml(((string)null).TrustedRaw()).ShouldEqual(string.Empty);
+            GetHtml(string.Empty.TrustedRaw()).ShouldEqual(string.Empty);
+        }
+
+        [Test]
+        public async Task TrustedRaw_Task_PreservesUnsafeHtml()
+        {
+            var input = "<img onerror=\"evil()\" src=\"x\">";
+
+            GetHtml(await Task.FromResult(input).TrustedRaw()).ShouldEqual(input);
+        }
+
         // ---- HtmlSanitizerFactory: config-driven policy + ShowRemoved markers ----
         // These build a sanitizer directly (Create) so they test the policy mapping without
         // touching the cached shared instance or needing an initialized Context.


### PR DESCRIPTION
Introduce TrustedRaw extension methods for string and Task<string> to render trusted HTML without sanitization. Update Raw method documentation to recommend TrustedRaw for trusted content, clarifying security intent. Add unit tests for TrustedRaw behavior. Bump Olive.Mvc version to 10.1.1.