### PR TITLE
Update AzureBlobStorageProvider to use DeleteBlobIfExistsAsync and bump version to 10.0.1

### DIFF
--- a/Olive.Blob.Azure/AzureBlobStorageProvider.cs
+++ b/Olive.Blob.Azure/AzureBlobStorageProvider.cs
@@ -152,7 +152,7 @@ namespace Olive.BlobAzure
 
             try
             {
-                await blobContainer.DeleteBlobAsync(document.GetKey());
+                await blobContainer.DeleteBlobIfExistsAsync(key, DeleteSnapshotsOption.IncludeSnapshots);
             }
             catch (Exception ex)
             {
@@ -170,7 +170,7 @@ namespace Olive.BlobAzure
 
             try
             {
-                await blobContainer.DeleteBlobAsync(document.GetKey());
+                await blobContainer.DeleteBlobIfExistsAsync(key, DeleteSnapshotsOption.IncludeSnapshots);
             }
             catch (Exception ex)
             {

--- a/Olive.Blob.Azure/Olive.Blob.Azure.csproj
+++ b/Olive.Blob.Azure/Olive.Blob.Azure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.0.0</Version>
+    <Version>10.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The code currently triggers an unnecessary runtime error if a file is missing from Azure blob storage. Additionally, if versioning is enabled, the delete function fails unless snapshots are also included.