### PR TITLE
Omit null Attachments in Microsoft365 email send.

### DIFF
--- a/Olive.Email.Microsoft365/Microsoft365EmailDispatcher.cs
+++ b/Olive.Email.Microsoft365/Microsoft365EmailDispatcher.cs
@@ -26,23 +26,25 @@ namespace Olive.Email.Microsoft365
             var credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
             using var graphClient = new GraphServiceClient(credential);
 
-            var requestBody = new SendMailPostRequestBody
+            var graphMessage = new Message
             {
-                Message = new Message
+                Subject = mail.Subject,
+                Body = new ItemBody
                 {
-                    Subject = mail.Subject,
-                    Body = new ItemBody
-                    {
-                        ContentType = message.Html ? BodyType.Html : BodyType.Text,
-                        Content = mail.Body
-                    },
-                    ToRecipients = ToRecipients(mail.To),
-                    CcRecipients = ToRecipients(mail.CC),
-                    BccRecipients = ToRecipients(mail.Bcc),
-                    ReplyTo = ToRecipients(mail.ReplyToList),
-                    Attachments = CreateAttachments(mail, message)
-                }
+                    ContentType = message.Html ? BodyType.Html : BodyType.Text,
+                    Content = mail.Body
+                },
+                ToRecipients = ToRecipients(mail.To),
+                CcRecipients = ToRecipients(mail.CC),
+                BccRecipients = ToRecipients(mail.Bcc),
+                ReplyTo = ToRecipients(mail.ReplyToList)
             };
+
+            var attachments = CreateAttachments(mail, message);
+            if (attachments.Any())
+                graphMessage.Attachments = attachments;
+
+            var requestBody = new SendMailPostRequestBody { Message = graphMessage };
 
             await graphClient.Users[senderAddress].SendMail.PostAsync(requestBody);
         }
@@ -79,7 +81,7 @@ namespace Olive.Email.Microsoft365
                 });
             }
 
-            return result.None() ? null : result;
+            return result;
         }
 
         static byte[] ReadBytes(Stream stream)

--- a/Olive.Email.Microsoft365/Olive.Email.Microsoft365.csproj
+++ b/Olive.Email.Microsoft365/Olive.Email.Microsoft365.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.2.0</Version>
+    <Version>10.2.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Graph rejects attachments serialized as null when a mail has no files; only set the property when attachments exist and bump the package to 10.2.1.