### PR TITLE
Cache filtered GetList()/Count() queries, not just unfiltered lists

### DIFF
--- a/Olive.Entities.Data/Caching/Cache.cs
+++ b/Olive.Entities.Data/Caching/Cache.cs
@@ -57,7 +57,10 @@ namespace Olive.Entities.Data
             CacheProvider.Remove(type, invalidateCachedReferences);
 
             foreach (var inherited in type.Assembly.GetSubTypes(type, withDescendants: true))
+            {
                 CacheProvider.Remove(inherited, invalidateCachedReferences);
+                (CacheProvider as IQueryCacheProvider)?.RemoveQueryResults(inherited);
+            }
         }
 
         public virtual void RemoveList(Type type)
@@ -85,9 +88,9 @@ namespace Olive.Entities.Data
         /// Caches the result of a filtered query under its own signature.
         /// No-op if the type isn't cacheable or the provider doesn't support query caching.
         /// </summary>
-        public void AddQueryResult(Type type, string key, object result)
+        public void AddQueryResult(Type type, string key, object result, DateTime? queryTime = null)
         {
-            if (IsCacheable(type)) (CacheProvider as IQueryCacheProvider)?.SetQueryResult(type, key, result);
+            if (IsCacheable(type)) (CacheProvider as IQueryCacheProvider)?.SetQueryResult(type, key, result, queryTime);
         }
 
         public virtual IEnumerable GetList(Type type)

--- a/Olive.Entities.Data/Caching/Cache.cs
+++ b/Olive.Entities.Data/Caching/Cache.cs
@@ -65,7 +65,29 @@ namespace Olive.Entities.Data
             if (!IsCacheable(type)) return;
 
             for (var parentType = type; parentType != typeof(Entity); parentType = parentType.BaseType)
+            {
                 CacheProvider.RemoveList(parentType);
+                (CacheProvider as IQueryCacheProvider)?.RemoveQueryResults(parentType);
+            }
+        }
+
+        /// <summary>
+        /// Gets a previously cached result for a filtered query (keyed by the query's own signature).
+        /// Returns null if not cached, the type isn't cacheable, or the provider doesn't support query caching.
+        /// </summary>
+        public object GetQueryResult(Type type, string key)
+        {
+            if (!IsCacheable(type)) return null;
+            return (CacheProvider as IQueryCacheProvider)?.GetQueryResult(type, key);
+        }
+
+        /// <summary>
+        /// Caches the result of a filtered query under its own signature.
+        /// No-op if the type isn't cacheable or the provider doesn't support query caching.
+        /// </summary>
+        public void AddQueryResult(Type type, string key, object result)
+        {
+            if (IsCacheable(type)) (CacheProvider as IQueryCacheProvider)?.SetQueryResult(type, key, result);
         }
 
         public virtual IEnumerable GetList(Type type)

--- a/Olive.Entities.Data/Caching/IQueryCacheProvider.cs
+++ b/Olive.Entities.Data/Caching/IQueryCacheProvider.cs
@@ -10,7 +10,7 @@ namespace Olive.Entities.Data
     public interface IQueryCacheProvider : ICacheProvider
     {
         object GetQueryResult(Type type, string key);
-        void SetQueryResult(Type type, string key, object result);
+        void SetQueryResult(Type type, string key, object result, DateTime? queryTime = null);
         void RemoveQueryResults(Type type);
     }
 }

--- a/Olive.Entities.Data/Caching/IQueryCacheProvider.cs
+++ b/Olive.Entities.Data/Caching/IQueryCacheProvider.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Olive.Entities.Data
+{
+    /// <summary>
+    /// An optional capability for an ICacheProvider to also cache the results of filtered
+    /// queries (GetList()/Count() with criteria), keyed by a query signature.
+    /// Providers that don't implement this (e.g. RedisCacheProvider) simply don't get this feature.
+    /// </summary>
+    public interface IQueryCacheProvider : ICacheProvider
+    {
+        object GetQueryResult(Type type, string key);
+        void SetQueryResult(Type type, string key, object result);
+        void RemoveQueryResults(Type type);
+    }
+}

--- a/Olive.Entities.Data/Caching/InMemoryCacheProvider.cs
+++ b/Olive.Entities.Data/Caching/InMemoryCacheProvider.cs
@@ -8,10 +8,13 @@ namespace Olive.Entities.Data
     /// <summary>
     /// Provides a cache of objects retrieved from the database.
     /// </summary>
-    public partial class InMemoryCacheProvider : ICacheProvider
+    public partial class InMemoryCacheProvider : ICacheProvider, IQueryCacheProvider
     {
         ConcurrentDictionary<Type, Dictionary<string, IEntity>> Types = new ConcurrentDictionary<Type, Dictionary<string, IEntity>>();
         ConcurrentDictionary<Type, IEnumerable> Lists = new ConcurrentDictionary<Type, IEnumerable>();
+        ConcurrentDictionary<Type, ConcurrentDictionary<string, object>> Queries = new ConcurrentDictionary<Type, ConcurrentDictionary<string, object>>();
+        int? maxCachedQueriesPerType;
+        int MaxCachedQueriesPerType => maxCachedQueriesPerType ??= Config.Get("Database:Cache:MaxCachedQueriesPerType", 200);
 
         Dictionary<string, IEntity> GetEntities(Type type) =>
             Types.GetOrAdd(type, t => new Dictionary<string, IEntity>());
@@ -77,11 +80,27 @@ namespace Olive.Entities.Data
 
         public void AddList(Type type, IEnumerable list) => Lists[type] = list;
 
+        public object GetQueryResult(Type type, string key) => Queries.GetOrDefault(type)?.GetOrDefault(key);
+
+        public void SetQueryResult(Type type, string key, object result)
+        {
+            var queries = Queries.GetOrAdd(type, t => new ConcurrentDictionary<string, object>());
+
+            // ponytail: crude cap, clears the whole type's query cache at the threshold instead of
+            // evicting individual entries by age. Upgrade to real LRU if a hot type keeps churning past the cap.
+            if (queries.Count >= MaxCachedQueriesPerType) queries.Clear();
+
+            queries[key] = result;
+        }
+
+        public void RemoveQueryResults(Type type) => Queries.TryRemove(type, out _);
+
         public void ClearAll()
         {
             RowVersionCache = new ConcurrentDictionary<Type, ConcurrentDictionary<string, long>>();
             Types.Clear();
             Lists.Clear();
+            Queries.Clear();
         }
     }
 }

--- a/Olive.Entities.Data/Caching/InMemoryCacheProvider.cs
+++ b/Olive.Entities.Data/Caching/InMemoryCacheProvider.cs
@@ -13,6 +13,7 @@ namespace Olive.Entities.Data
         ConcurrentDictionary<Type, Dictionary<string, IEntity>> Types = new ConcurrentDictionary<Type, Dictionary<string, IEntity>>();
         ConcurrentDictionary<Type, IEnumerable> Lists = new ConcurrentDictionary<Type, IEnumerable>();
         ConcurrentDictionary<Type, ConcurrentDictionary<string, object>> Queries = new ConcurrentDictionary<Type, ConcurrentDictionary<string, object>>();
+        ConcurrentDictionary<Type, long> QueryResultsInvalidatedAt = new ConcurrentDictionary<Type, long>();
         int? maxCachedQueriesPerType;
         int MaxCachedQueriesPerType => maxCachedQueriesPerType ??= Config.Get("Database:Cache:MaxCachedQueriesPerType", 200);
 
@@ -82,18 +83,22 @@ namespace Olive.Entities.Data
 
         public object GetQueryResult(Type type, string key) => Queries.GetOrDefault(type)?.GetOrDefault(key);
 
-        public void SetQueryResult(Type type, string key, object result)
+        public void SetQueryResult(Type type, string key, object result, DateTime? queryTime = null)
         {
+            if (queryTime.HasValue && QueryResultsInvalidatedAt.GetOrDefault(type) > queryTime.Value.Ticks) return;
+
             var queries = Queries.GetOrAdd(type, t => new ConcurrentDictionary<string, object>());
 
-            // ponytail: crude cap, clears the whole type's query cache at the threshold instead of
-            // evicting individual entries by age. Upgrade to real LRU if a hot type keeps churning past the cap.
             if (queries.Count >= MaxCachedQueriesPerType) queries.Clear();
 
             queries[key] = result;
         }
 
-        public void RemoveQueryResults(Type type) => Queries.TryRemove(type, out _);
+        public void RemoveQueryResults(Type type)
+        {
+            QueryResultsInvalidatedAt[type] = DateTime.UtcNow.Ticks;
+            Queries.TryRemove(type, out _);
+        }
 
         public void ClearAll()
         {
@@ -101,6 +106,7 @@ namespace Olive.Entities.Data
             Types.Clear();
             Lists.Clear();
             Queries.Clear();
+            QueryResultsInvalidatedAt.Clear();
         }
     }
 }

--- a/Olive.Entities.Data/Olive.Entities.Data.csproj
+++ b/Olive.Entities.Data/Olive.Entities.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>10.3.0</Version>
+    <Version>10.4.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Olive.Entities.Data/QueryExecution/DatabaseQuery.Execution.cs
+++ b/Olive.Entities.Data/QueryExecution/DatabaseQuery.Execution.cs
@@ -7,19 +7,35 @@
 
     partial class DatabaseQuery
     {
+        static IEnumerable<ICriterion> Flatten(IEnumerable<ICriterion> criteria)
+        {
+            foreach (var criterion in criteria)
+            {
+                if (criterion is BinaryCriterion binary)
+                {
+                    foreach (var inner in Flatten(new ICriterion[] { binary.Left, binary.Right }.ExceptNull()))
+                        yield return inner;
+                }
+                else yield return criterion;
+            }
+        }
+
         bool IsCacheable()
         {
             if ((TakeTop.HasValue && TakeTop != 1) || PageSize.HasValue || Columns.Any()) return false;
 
-            // A cached result array bakes in whatever Include() shape was requested at cache-write
-            // time; a different Include() set on a later identical-criteria call would silently get
-            // the wrong (missing or superfluous) eager-loaded associations. Keep these uncached for now.
+            // The soft-delete bypass context changes the generated SQL but is invisible to cache keys.
+            if (SoftDeleteAttribute.Context.ShouldByPassSoftDelete()) return false;
+
+            // We don't cache queries that include associations, because the included associations may change without changing the main entity.
             if (Include.Any()) return false;
 
-            if (Criteria.Except(typeof(DirectDatabaseCriterion)).Any(c => c.PropertyName.Contains(".")))
+            var criteria = Flatten(Criteria).ToArray();
+
+            if (criteria.Except(typeof(DirectDatabaseCriterion)).Any(c => c.PropertyName.Contains(".")))
                 return false; // This doesn't work with cache expiration rules.
 
-            if (Criteria.OfType<DirectDatabaseCriterion>().Any(x => !x.IsCacheSafe))
+            if (criteria.OfType<DirectDatabaseCriterion>().Any(x => !x.IsCacheSafe))
                 return false;
 
             // Do not cache a polymorphic call:
@@ -28,9 +44,11 @@
             return true;
         }
 
-        string GetQueryCacheKey(string prefix = null) =>
-            prefix + Criteria.Select(c => c.ToString()).OrderBy(x => x).ToString("|") +
-            "##" + OrderByParts.Select(o => o.ToString()).ToString(",") +
+        string GetCriteriaCacheKey(string prefix = null) =>
+            prefix + Criteria.Select(c => c.ToString()).OrderBy(x => x).ToString("|");
+
+        string GetQueryCacheKey() =>
+            GetCriteriaCacheKey() + "##" + OrderByParts.Select(o => o.ToString()).ToString(",") +
             "##top:" + TakeTop;
 
         public async Task<IEntity[]> GetList()
@@ -40,28 +58,22 @@
             if (Context.Current.Database().AnyOpenTransaction())
                 return await LoadFromDatabaseAndCache().ToArray();
 
-            if (Criteria.Any())
+            if (Criteria.Any() || TakeTop.HasValue)
             {
                 var cacheKey = GetQueryCacheKey();
                 var queryCache = Cache as Cache;
 
                 if (queryCache?.GetQueryResult(EntityType, cacheKey) is IEntity[] cached)
-                {
-                    await LoadIncludedAssociations(cached);
-                    return cached;
-                }
+                    return cached.ToArray();
 
+                var timestamp = Cache.GetQueryTimestamp();
                 var queried = await LoadFromDatabaseAndCache().ToArray();
-                queryCache?.AddQueryResult(EntityType, cacheKey, queried);
+                queryCache?.AddQueryResult(EntityType, cacheKey, queried, timestamp);
                 return queried;
             }
 
             var result = Cache.GetList(EntityType)?.Cast<IEntity>().ToArray();
-            if (result != null)
-            {
-                await LoadIncludedAssociations(result);
-                return result;
-            }
+            if (result != null) return result;
 
             result = await LoadFromDatabaseAndCache().ToArray();
 
@@ -132,13 +144,14 @@
             if (!IsCacheable() || Context.Current.Database().AnyOpenTransaction())
                 return await Provider.Count(this);
 
-            var cacheKey = GetQueryCacheKey("count:");
+            var cacheKey = GetCriteriaCacheKey("count:");
             var queryCache = Cache as Cache;
 
             if (queryCache?.GetQueryResult(EntityType, cacheKey) is int cached) return cached;
 
+            var timestamp = Cache.GetQueryTimestamp();
             var count = await Provider.Count(this);
-            queryCache?.AddQueryResult(EntityType, cacheKey, count);
+            queryCache?.AddQueryResult(EntityType, cacheKey, count, timestamp);
             return count;
         }
 

--- a/Olive.Entities.Data/QueryExecution/DatabaseQuery.Execution.cs
+++ b/Olive.Entities.Data/QueryExecution/DatabaseQuery.Execution.cs
@@ -9,7 +9,12 @@
     {
         bool IsCacheable()
         {
-            if (TakeTop.HasValue || PageSize.HasValue || Columns.Any()) return false;
+            if ((TakeTop.HasValue && TakeTop != 1) || PageSize.HasValue || Columns.Any()) return false;
+
+            // A cached result array bakes in whatever Include() shape was requested at cache-write
+            // time; a different Include() set on a later identical-criteria call would silently get
+            // the wrong (missing or superfluous) eager-loaded associations. Keep these uncached for now.
+            if (Include.Any()) return false;
 
             if (Criteria.Except(typeof(DirectDatabaseCriterion)).Any(c => c.PropertyName.Contains(".")))
                 return false; // This doesn't work with cache expiration rules.
@@ -23,12 +28,33 @@
             return true;
         }
 
+        string GetQueryCacheKey(string prefix = null) =>
+            prefix + Criteria.Select(c => c.ToString()).OrderBy(x => x).ToString("|") +
+            "##" + OrderByParts.Select(o => o.ToString()).ToString(",") +
+            "##top:" + TakeTop;
+
         public async Task<IEntity[]> GetList()
         {
             if (!IsCacheable()) return await LoadFromDatabase().ToArray();
 
-            if (Criteria.Any() || Context.Current.Database().AnyOpenTransaction())
+            if (Context.Current.Database().AnyOpenTransaction())
                 return await LoadFromDatabaseAndCache().ToArray();
+
+            if (Criteria.Any())
+            {
+                var cacheKey = GetQueryCacheKey();
+                var queryCache = Cache as Cache;
+
+                if (queryCache?.GetQueryResult(EntityType, cacheKey) is IEntity[] cached)
+                {
+                    await LoadIncludedAssociations(cached);
+                    return cached;
+                }
+
+                var queried = await LoadFromDatabaseAndCache().ToArray();
+                queryCache?.AddQueryResult(EntityType, cacheKey, queried);
+                return queried;
+            }
 
             var result = Cache.GetList(EntityType)?.Cast<IEntity>().ToArray();
             if (result != null)
@@ -101,7 +127,20 @@
             return result;
         }
 
-        public Task<int> Count() => Provider.Count(this);
+        public async Task<int> Count()
+        {
+            if (!IsCacheable() || Context.Current.Database().AnyOpenTransaction())
+                return await Provider.Count(this);
+
+            var cacheKey = GetQueryCacheKey("count:");
+            var queryCache = Cache as Cache;
+
+            if (queryCache?.GetQueryResult(EntityType, cacheKey) is int cached) return cached;
+
+            var count = await Provider.Count(this);
+            queryCache?.AddQueryResult(EntityType, cacheKey, count);
+            return count;
+        }
 
         public async Task<bool> Any() => await Count() > 0;
 

--- a/Olive.Entities/Database/Criterion.cs
+++ b/Olive.Entities/Database/Criterion.cs
@@ -110,6 +110,11 @@ namespace Olive.Entities
             {
                 return asEnum.ToString("|");
             }
+            else if (Value is DateTime dateTime)
+            {
+                // Round-trip format: culture-invariant and keeps sub-second precision.
+                return dateTime.ToString("O");
+            }
             else
             {
                 return Value?.ToStringOrEmpty();

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,6 +1,9 @@
 
 # Olive compatibility change log
 
+## 17 Aug 2026
+- Filtered `GetList()`/`Count()`/`FirstOrDefault()` queries (i.e. with `Where(...)` criteria) are now cached, the same way unfiltered lists and single-entity lookups already were. This is automatic for any type that already has caching enabled (via `[CacheObjects]` or the global `Database:Cache` setting) — no code changes required. See [Caching](Entities/Cache.md) for what is/isn't cached, the new `Database:Cache:MaxCachedQueriesPerType` setting, and the Redis-provider caveat (filtered-query caching is in-process-provider only for now).
+
 ## 11 Jan 2022 (.NET 6.0 upgrade)
 1. Create the folder `M#\lib\net6.0` and inside it, create a text file named `MSharp.DSL.runtimeconfig.json` with the following content ```{ "runtimeOptions": { "tfm": "net6.0", "framework": { "name": "Microsoft.NETCore.App","version": "6.0.0" } } }```
 2. Open a command prompt in `M#\lib\net6.0` and run this command: ```git add MSharp.DSL.runtimeconfig.json -f```

--- a/docs/Entities/Cache.md
+++ b/docs/Entities/Cache.md
@@ -1,0 +1,84 @@
+
+# Caching
+
+Olive's ORM has a built-in cache for entities, sitting between `IDatabase` and the database itself. It reduces database round-trips for repeated reads, and is kept consistent automatically: any `Save`/`Delete` invalidates exactly what it needs to.
+
+## What gets cached automatically
+
+- **Single entity lookups** — `Database.Get<T>(id)` and `Database.GetOrDefault<T>(id)`.
+- **Unfiltered list queries** — `Database.GetList<T>()` with no criteria.
+- **Filtered list queries, counts and `FirstOrDefault`** — `Database.Of<T>().Where(...).GetList()`, `.Count()`, and `.FirstOrDefault()` (including the convenience overloads `Database.GetList<T>(criteria)`, `Database.Count<T>(criteria)`, `Database.FirstOrDefault<T>(criteria)`).
+
+You don't need to change your code to benefit from this — if a type is cacheable (see below), matching queries are served from memory instead of hitting the database again.
+
+A filtered query is **not** cached when it:
+- Uses paging (`Top(n)` for `n > 1`, or `PageSize`) — `FirstOrDefault()`/`Top(1)` is the one exception, and *is* cached.
+- Selects specific columns (`Select(...)`).
+- Uses `.Include(...)` to eager-load associations (a cached result would bake in whichever `Include` shape was requested first, so these always hit the database).
+- Filters on a dotted/association-traversing property (e.g. `x.Customer.Country == "UK"`) — only direct properties of the queried type are safe to cache.
+- Needs polymorphic type resolution.
+
+## Enabling caching for a type
+
+Caching is controlled per type with the `[CacheObjects]` attribute:
+
+```csharp
+[CacheObjects(true)]
+public class Product : GuidEntity { ... }
+```
+
+If a type has no `[CacheObjects]` attribute, it falls back to the global `Database:Cache` setting (see below). `[CacheObjects(false)]` always opts a type out, regardless of the global setting.
+
+## Cache modes
+
+Configured via `Database:Cache:Mode` in `appsettings.json`:
+
+```json
+"Database": {
+    "Cache": {
+        "Mode": "single-server"
+    }
+}
+```
+
+- `off` — caching disabled.
+- `single-server` — the traditional static in-process cache, shared across all requests for the lifetime of the app. Ideal when your app runs as a single instance (vertical scaling).
+- `multi-server` — the cache is scoped to a single HTTP request. Use this instead of `off` when your app is horizontally scaled across multiple instances/pods behind a load balancer: an in-process cache can't stay coherent across instances, so scoping it to one request avoids ever serving stale cross-instance data, while still deduplicating repeated loads within that one request.
+
+## Distributed caching (Redis)
+
+For a genuinely shared cache across multiple instances, add the `Olive.Entities.Cache.Redis` package and call:
+
+```csharp
+services.AddRedisCache();
+```
+
+This swaps in a Redis-backed `ICacheProvider` behind the same `ICache` interface, so all existing invalidation (on Save/Delete) keeps working unchanged. Two things to be aware of before using it:
+- It disables the concurrency-aware staleness check that the in-process provider has (`ConcurrencyAware` has no effect under Redis).
+- Filtered-query-result caching (above) is **not** available under Redis yet — only the in-process provider (`InMemoryCacheProvider`) implements it. Queries with criteria will still hit the database when Redis is the active provider.
+
+## Growth control for filtered-query caching
+
+Because a filtered query's cache key includes its criteria, a type queried with many different filter combinations (e.g. a search screen with several optional fields) can accumulate many distinct cache entries. To bound this, the in-process provider caps how many distinct query results it keeps per type:
+
+```json
+"Database": {
+    "Cache": {
+        "MaxCachedQueriesPerType": 200
+    }
+}
+```
+
+Once a type's cache hits this many entries, the bucket is cleared before the next one is added. The default is `200`; raise it for types with many legitimate filter combinations and a low write rate, or lower it for memory-constrained deployments.
+
+## Invalidation
+
+Any `Save` or `Delete` of an entity invalidates **all** cached data for that type — the single entity, the unfiltered list, and every cached filtered query result. This is intentionally coarse (not per-row or per-query-shape) to keep the guarantee simple: after any write to a type, the next read of that type is always fresh.
+
+## Manually clearing the cache
+
+```csharp
+await Context.Current.Database().Refresh();
+```
+
+This clears the entire cache (all types) and raises `IDatabase.CacheRefreshed`.

--- a/docs/Entities/Cache.md
+++ b/docs/Entities/Cache.md
@@ -17,6 +17,7 @@ A filtered query is **not** cached when it:
 - Uses `.Include(...)` to eager-load associations (a cached result would bake in whichever `Include` shape was requested first, so these always hit the database).
 - Filters on a dotted/association-traversing property (e.g. `x.Customer.Country == "UK"`) — only direct properties of the queried type are safe to cache.
 - Needs polymorphic type resolution.
+- Runs under an active soft-delete bypass context (`SoftDeleteAttribute.Context`).
 
 ## Enabling caching for a type
 
@@ -82,3 +83,9 @@ await Context.Current.Database().Refresh();
 ```
 
 This clears the entire cache (all types) and raises `IDatabase.CacheRefreshed`.
+
+## Known limitations
+
+- Raw SQL writes (e.g. `ExecuteNonQuery`) bypass `Save`/`Delete` and therefore never invalidate cached query results — after raw writes, call `Database.Refresh()` or expect staleness until the next normal write to the type.
+- Query-result caching requires the registered `ICache` to be Olive's `Cache` class itself; a custom `ICache` decorator silently disables it (deliberate for now).
+- `DirectDatabaseCriterion.IsCacheSafe` also opts the criterion into result-set caching, not just entity-level caching — set it only when the SQL's result depends solely on data of the queried type.


### PR DESCRIPTION
## Summary
- Extends Olive.Entities.Data's in-process cache to also serve filtered GetList()/Count()/FirstOrDefault() queries (i.e. calls with Where(...) criteria) from memory, not just unfiltered lists and single-entity lookups.
- Adds an optional IQueryCacheProvider capability (implemented by InMemoryCacheProvider) so query-result caching only applies where a provider supports it; RedisCacheProvider is unaffected and continues to hit the database for filtered queries.
- Query cache entries are keyed by query signature (criteria + order-by + top) and are invalidated alongside the rest of a type's cache on Save/Delete.
- Adds a Database:Cache:MaxCachedQueriesPerType setting (default 200) to bound unbounded growth from many distinct filter combinations on the same type; the bucket is cleared once the cap is hit.
- Queries using .Include(...), paging beyond Top(1), column selection, or dotted/association-traversing criteria remain uncached, same as before.
- Bumps Olive.Entities.Data to v10.4.0 and documents the feature in docs/Entities/Cache.md, with a changelog entry.
