### PR TITLE
Generate Count(ID) instead of Count(*) for a cheaper count query

### DIFF
--- a/Olive.Entities.Data/Ado.Net/DataProvider.cs
+++ b/Olive.Entities.Data/Ado.Net/DataProvider.cs
@@ -337,7 +337,7 @@ namespace Olive.Entities.Data
             if (query.TakeTop.HasValue)
                 throw new ArgumentException("TakeTop cannot be used for Count().");
 
-            return $"SELECT Count(*) FROM {GetTables()} {GenerateWhere(query)}";
+            return $"SELECT Count({MapColumn("ID")}) FROM {GetTables()} {GenerateWhere(query)}";
         }
 
         public virtual string GenerateSort(DatabaseQuery query)

--- a/Olive.Entities.Data/Olive.Entities.Data.csproj
+++ b/Olive.Entities.Data/Olive.Entities.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>10.4.0</Version>
+    <Version>10.4.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,6 +1,9 @@
 
 # Olive compatibility change log
 
+## 25 Aug 2026
+- `Count()` queries (SQL Server, MySQL, PostgreSQL, SQLite) now generate `SELECT Count(ID)` instead of `SELECT Count(*)`, for a cheaper index-only count on wide tables. Result is unchanged; no code changes required. `Olive.Entities.Data` bumped to `10.4.1`.
+
 ## 17 Aug 2026
 - Filtered `GetList()`/`Count()`/`FirstOrDefault()` queries (i.e. with `Where(...)` criteria) are now cached, the same way unfiltered lists and single-entity lookups already were. This is automatic for any type that already has caching enabled (via `[CacheObjects]` or the global `Database:Cache` setting) — no code changes required. See [Caching](Entities/Cache.md) for what is/isn't cached, the new `Database:Cache:MaxCachedQueriesPerType` setting, and the Redis-provider caveat (filtered-query caching is in-process-provider only for now).
 

--- a/docs/Entities/IDatabaseQuery.md
+++ b/docs/Entities/IDatabaseQuery.md
@@ -58,3 +58,7 @@ async Task<IEnumerable<TaskItem>> GetPage(int pageIndex, int pageSize, DateTime?
     return await query.GetList();
 }
 ```
+
+## Count()
+
+`query.Count()` (and `Database.Count<T>(...)`) generate `SELECT Count(ID) FROM ...` rather than `SELECT Count(*) FROM ...`. Counting the primary key column lets SQL Server satisfy the query from the narrower primary key index instead of scanning/materializing every column of every matching row, which is cheaper on wide tables. The result is identical to `Count(*)`, since `ID` is a mandatory, non-null column on every entity.


### PR DESCRIPTION
Count(ID) lets SQL Server (and MySQL/PostgreSQL/SQLite, which share the same DataProvider.GenerateCountCommand) satisfy the count from the narrower primary key index instead of scanning every column of every matching row, without changing the result.