### PR TITLE
Fix Select(columns) narrowing and add expression-based overload

### DIFF
--- a/Olive.Entities.Data/GenericDataProvider/DataProvider.cs
+++ b/Olive.Entities.Data/GenericDataProvider/DataProvider.cs
@@ -15,6 +15,9 @@ namespace Olive.Entities.Data
         readonly Dictionary<string, string> ColumnMapping = new();
         readonly Dictionary<string, string> SubqueryMapping = new();
 
+        // Always fetched even when Select() narrows columns: needed for identity and polymorphic type resolution.
+        HashSet<string> MandatoryFields;
+
         public ISqlCommandGenerator SqlCommandGenerator { get; }
 
         public IDataProviderMetaData MetaData { get; }
@@ -100,7 +103,14 @@ namespace Olive.Entities.Data
         string GetFields(IDatabaseQuery query)
         {
             if (query is DatabaseQuery q && q.Columns.Any())
-                return AllFields.Where(v => q.Columns.Contains(v.Name)).ToString(", ");
+            {
+                var invalid = q.Columns.Except(AllFields.Select(v => v.Name)).ToArray();
+                if (invalid.Any())
+                    throw new ArgumentException(
+                        $"'{invalid.ToString(", ")}' is not a valid property of '{EntityType.Name}' to use in Select().");
+
+                return AllFields.Where(v => MandatoryFields.Contains(v.Name) || q.Columns.Contains(v.Name)).ToString(", ");
+            }
             else
                 return GetFields();
         }
@@ -267,6 +277,9 @@ namespace Olive.Entities.Data
             AllFields = MetaData.BaseClassesInOrder.Concat(MetaData).Concat(MetaData.DrivedClasses)
                 .SelectMany(parent => parent.UserDefienedAndIdAndDeletedProperties.Select(prop => GetField(parent, prop)))
                 .ToArray();
+
+            MandatoryFields = new HashSet<string>(
+                MetaData.BaseClassesInOrder.Concat(MetaData).Concat(MetaData.DrivedClasses).Select(m => m.IdColumnName));
         }
 
         void PrepareColumnMappingDictonary()

--- a/Olive.Entities.Data/Olive.Entities.Data.csproj
+++ b/Olive.Entities.Data/Olive.Entities.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>10.4.1</Version>
+    <Version>10.4.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Olive.Entities.Data/QueryExecution/DatabaseQuery.TEntity.cs
+++ b/Olive.Entities.Data/QueryExecution/DatabaseQuery.TEntity.cs
@@ -1,6 +1,7 @@
 ﻿namespace Olive.Entities.Data
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
     using System.Threading.Tasks;
@@ -27,6 +28,23 @@
         {
             ((IDatabaseQuery)this).Select(colunms);
             return this;
+        }
+
+        IDatabaseQuery<TEntity> IDatabaseQuery<TEntity>.Select(Expression<Func<TEntity, object>> columns)
+        {
+            var names = ExtractSelectColumnNames(columns.Body).ToArray();
+            return ((IDatabaseQuery<TEntity>)this).Select(names);
+        }
+
+        static IEnumerable<string> ExtractSelectColumnNames(Expression expression)
+        {
+            if (expression is UnaryExpression unary && unary.NodeType == ExpressionType.Convert)
+                return ExtractSelectColumnNames(unary.Operand);
+
+            if (expression is NewExpression @new)
+                return @new.Arguments.Select(a => a.GetPropertyPath());
+
+            return new[] { expression.GetPropertyPath() };
         }
 
         IDatabaseQuery<TEntity> IDatabaseQuery<TEntity>.Top(int rows)

--- a/Olive.Entities/Abstractions/IDatabaseQuery.cs
+++ b/Olive.Entities/Abstractions/IDatabaseQuery.cs
@@ -58,6 +58,7 @@ namespace Olive.Entities
         new IDatabaseQuery<TEntity> Top(int rows);
         new IDatabaseQuery<TEntity> Where(params ICriterion[] criteria);
         new IDatabaseQuery<TEntity> Select(params string[] columns);
+        IDatabaseQuery<TEntity> Select(Expression<Func<TEntity, object>> columns);
 
         IDatabaseQuery<TEntity> ThenBy(Expression<Func<TEntity, object>> property, bool descending = false);
         IDatabaseQuery<TEntity> OrderByDescending(Expression<Func<TEntity, object>> property);

--- a/Olive.Entities/Olive.Entities.csproj
+++ b/Olive.Entities/Olive.Entities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>10.2.0</Version>
+    <Version>10.2.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,6 +1,9 @@
 
 # Olive compatibility change log
 
+## 25 Aug 2026 (2)
+- Fixed `Select(columns)` on `Database.Of<T>()`/`GetList<T>()` queries: it now always fetches the ID column(s) needed for identity and polymorphic type resolution (previously omitting `ID` broke it), and an unknown column name now throws immediately instead of generating invalid SQL. Added a new `Select(x => x.Property)` / `Select(x => new { x.A, x.B })` overload so columns can be referenced via a lambda instead of hard-coded strings. See [IDatabaseQuery](Entities/IDatabaseQuery.md#selectcolumns). No code changes required unless you were already relying on the old broken behaviour. `Olive.Entities` bumped to `10.2.1`, `Olive.Entities.Data` bumped to `10.4.2`.
+
 ## 25 Aug 2026
 - `Count()` queries (SQL Server, MySQL, PostgreSQL, SQLite) now generate `SELECT Count(ID)` instead of `SELECT Count(*)`, for a cheaper index-only count on wide tables. Result is unchanged; no code changes required. `Olive.Entities.Data` bumped to `10.4.1`.
 

--- a/docs/Entities/IDatabaseQuery.md
+++ b/docs/Entities/IDatabaseQuery.md
@@ -62,3 +62,22 @@ async Task<IEnumerable<TaskItem>> GetPage(int pageIndex, int pageSize, DateTime?
 ## Count()
 
 `query.Count()` (and `Database.Count<T>(...)`) generate `SELECT Count(ID) FROM ...` rather than `SELECT Count(*) FROM ...`. Counting the primary key column lets SQL Server satisfy the query from the narrower primary key index instead of scanning/materializing every column of every matching row, which is cheaper on wide tables. The result is identical to `Count(*)`, since `ID` is a mandatory, non-null column on every entity.
+
+## Select(columns)
+
+When you only need a few columns of a large entity, `Select(...)` narrows the SQL field list to just those columns, instead of fetching every column. The ID column (and, for polymorphic types, the base/derived class ID columns) is always fetched regardless, so the returned entities keep a working identity - properties that were not selected are simply left at their default value.
+
+You can specify the columns either by name, or with a lambda referencing the property(s):
+
+```csharp
+// By column name(s):
+var people = await Database.Of<Person>().Select("FirstName", "LastName").GetList();
+
+// By a single property:
+var people = await Database.Of<Person>().Select(x => x.FirstName).GetList();
+
+// By multiple properties, using an anonymous type:
+var people = await Database.Of<Person>().Select(x => new { x.FirstName, x.LastName }).GetList();
+```
+
+An unknown column name, or an expression that isn't a direct property of the entity (e.g. an association path like `x.Product.Type.Rate`, or a method call like `x.FirstName.ToUpper()`), will throw immediately rather than generating invalid SQL. Selecting fields from association chains, returned as a custom/anonymous projection type, is not supported yet.


### PR DESCRIPTION
Select() was dropping the mandatory ID column(s) needed for identity and polymorphic type resolution, and silently produced invalid SQL for unknown column names. Also adds Select(x => x.Property) / Select(x => new { x.A, x.B }) so columns can be referenced via a lambda instead of hard-coded strings.