### PR TITLE
Avoid full row scans on Any()/None() and per-row GetSchemaTable() calls

### DIFF
--- a/Olive.Entities.Data/Ado.Net/DataProvider.cs
+++ b/Olive.Entities.Data/Ado.Net/DataProvider.cs
@@ -41,6 +41,31 @@ namespace Olive.Entities.Data
             return Convert.ToInt32(await ExecuteScalar(command, CommandType.Text, GenerateParameters(query.Parameters)));
         }
 
+        /// <summary>
+        /// Checks whether at least one matching row exists, stopping at the first match instead of
+        /// counting every matching row (which is what a Count() > 0 check would otherwise require).
+        /// </summary>
+        public async Task<bool> Any(IDatabaseQuery iquery)
+        {
+            var query = (DatabaseQuery)iquery;
+
+            // TakeTop/PageSize don't combine meaningfully with a plain existence probe.
+            // Count() already defines (and throws for) that case, so just defer to it.
+            if (query.PageSize.HasValue || query.TakeTop.HasValue)
+                return await Count(query) > 0;
+
+            query.TakeTop = 1;
+            try
+            {
+                var command = GenerateSelectCommand(query, "1");
+                return await ExecuteScalar(command, CommandType.Text, GenerateParameters(query.Parameters)) != null;
+            }
+            finally
+            {
+                query.TakeTop = null;
+            }
+        }
+
         public static List<string> ExtractIds(string idsXml) =>
             idsXml.Split(ExtractIdsSeparator, StringSplitOptions.RemoveEmptyEntries).ToList();
 

--- a/Olive.Entities.Data/Database/Database.cs
+++ b/Olive.Entities.Data/Database/Database.cs
@@ -112,13 +112,13 @@ namespace Olive.Entities.Data
         /// <summary>
         /// Determines if there is any object in the database of the specified type.
         /// </summary>
-        public async Task<bool> Any<T>() where T : IEntity => await Of<T>().Count() > 0;
+        public async Task<bool> Any<T>() where T : IEntity => await Of<T>().Any();
 
         /// <summary>
         /// Determines if there is any object in the database of the specified type matching a given criteria.
         /// </summary>
         public async Task<bool> Any<T>(Expression<Func<T, bool>> criteria) where T : IEntity =>
-            await Of<T>().Where(criteria).Count() > 0;
+            await Of<T>().Where(criteria).Any();
 
         /// <summary>
         /// Determines whether there is no object of the specified type in the database.

--- a/Olive.Entities.Data/GenericDataProvider/DataProvider.cs
+++ b/Olive.Entities.Data/GenericDataProvider/DataProvider.cs
@@ -1,9 +1,9 @@
 using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Data;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Olive.Entities.Data
@@ -217,12 +217,23 @@ namespace Olive.Entities.Data
             Entity.Services.SetOriginalId(record);
         }
 
+        static readonly ConditionalWeakTable<IDataReader, HashSet<string>> ReaderColumnsCache = new();
+
+        static HashSet<string> GetReaderColumns(IDataReader reader)
+        {
+            if (ReaderColumnsCache.TryGetValue(reader, out var cached)) return cached;
+
+            var columns = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            for (var i = 0; i < reader.FieldCount; i++)
+                columns.Add(reader.GetName(i));
+
+            ReaderColumnsCache.Add(reader, columns);
+            return columns;
+        }
+
         void FillData(IDataReader reader, IEntity entity)
         {
-            var schema = reader.GetSchemaTable();
-            var columns = schema.Rows.Cast<DataRow>()
-                                     .Select(r => r["ColumnName"].ToString())
-                                     .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+            var columns = GetReaderColumns(reader);
 
             var props = MetaData.GetPropertiesForFillData().ToArray();
 

--- a/Olive.Entities.Data/Olive.Entities.Data.csproj
+++ b/Olive.Entities.Data/Olive.Entities.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>10.4.2</Version>
+    <Version>10.4.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Olive.Entities.Data/QueryExecution/DatabaseQuery.Execution.cs
+++ b/Olive.Entities.Data/QueryExecution/DatabaseQuery.Execution.cs
@@ -155,7 +155,24 @@
             return count;
         }
 
-        public async Task<bool> Any() => await Count() > 0;
+        public async Task<bool> Any()
+        {
+            if (!IsCacheable() || Context.Current.Database().AnyOpenTransaction())
+                return await ExecuteAny();
+
+            var cacheKey = GetCriteriaCacheKey("any:");
+            var queryCache = Cache as Cache;
+
+            if (queryCache?.GetQueryResult(EntityType, cacheKey) is bool cached) return cached;
+
+            var timestamp = Cache.GetQueryTimestamp();
+            var result = await ExecuteAny();
+            queryCache?.AddQueryResult(EntityType, cacheKey, result, timestamp);
+            return result;
+        }
+
+        async Task<bool> ExecuteAny() =>
+            Provider is DataProvider adoProvider ? await adoProvider.Any(this) : await Provider.Count(this) > 0;
 
         public async Task<bool> None() => !await Any();
 

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,6 +1,9 @@
 
 # Olive compatibility change log
 
+## 4 Sep 2026
+- `Any()`/`None()` on `IDatabaseQuery` (and the `Database.Any<T>()`/`Any<T>(criteria)`/`None<T>(...)` convenience methods) now generate a `SELECT TOP 1 ...` existence probe instead of `SELECT Count(...) > 0`, so SQL Server/MySQL/PostgreSQL/SQLite can stop at the first matching row instead of aggregating over every match. Also fixed row parsing (`GetList()`/`Get()`) to stop calling `IDataReader.GetSchemaTable()` once per row (and once per base/derived table of that row) — the reader's column set is now read once per query execution and reused, which was a real cost on large result sets, especially combined with `Select(columns)` narrowing. Both are internal/behavioural improvements; no code changes required. `Olive.Entities.Data` bumped to `10.4.3`.
+
 ## 25 Aug 2026 (2)
 - Fixed `Select(columns)` on `Database.Of<T>()`/`GetList<T>()` queries: it now always fetches the ID column(s) needed for identity and polymorphic type resolution (previously omitting `ID` broke it), and an unknown column name now throws immediately instead of generating invalid SQL. Added a new `Select(x => x.Property)` / `Select(x => new { x.A, x.B })` overload so columns can be referenced via a lambda instead of hard-coded strings. See [IDatabaseQuery](Entities/IDatabaseQuery.md#selectcolumns). No code changes required unless you were already relying on the old broken behaviour. `Olive.Entities` bumped to `10.2.1`, `Olive.Entities.Data` bumped to `10.4.2`.
 


### PR DESCRIPTION
Any()/None() (both IDatabaseQuery and the Database.Any<T>/None<T> convenience methods) generated a SELECT Count(...) > 0, forcing the database to aggregate over every matching row just to answer a yes/no question. They now generate a SELECT TOP 1 existence probe instead, so the query can stop at the first match.

Row parsing (GetList()/Get()) called IDataReader.GetSchemaTable() once per row, and once per base/derived table of that row, to work out which columns Select(columns) had narrowed the query to. GetSchemaTable() builds a full metadata DataTable and is far more expensive than needed for a lookup that never changes across a single reader's lifetime; the column set is now computed once per query execution and cached against the reader instance.

Olive.Entities.Data bumped to 10.4.3.