### PR TITLE
Add IsSafe method and improve ShowRemoved tag handling

### DIFF
--- a/Olive.Mvc/Olive.Mvc.csproj
+++ b/Olive.Mvc/Olive.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.3.1</Version>
+    <Version>10.3.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Olive.Mvc/Utilities/HtmlSanitizerFactory.cs
+++ b/Olive.Mvc/Utilities/HtmlSanitizerFactory.cs
@@ -151,6 +151,17 @@ namespace Olive.Mvc
         }
 
         /// <summary>
+        /// True when <see cref="Sanitize(string)"/> gives back exactly this HTML, i.e. saving it
+        /// means the reader sees what the writer typed. Use it to reject input that the sanitizer
+        /// would change, instead of letting it be changed silently at render time.
+        /// <para>The test is an exact comparison, so a rewrite counts as well as a removal:
+        /// Sanitize() re-serializes the document, so <c>&lt;BR/&gt;</c> becomes <c>&lt;br&gt;</c>,
+        /// single quotes become double quotes, and an unclosed tag gets closed. Text matching
+        /// <see cref="HtmlSanitizerSettings.EncodePatterns"/> is encoded and counts too.</para>
+        /// </summary>
+        public static bool IsSafe(string html) => html.IsEmpty() || Sanitize(html) == html;
+
+        /// <summary>
         /// HTML-encodes every match of the given patterns, so the sanitizer's parser sees plain
         /// text instead of markup. The whole match is encoded.
         /// <para>This is how text that only looks like a tag survives, e.g. the C# generic
@@ -354,10 +365,10 @@ namespace Olive.Mvc
 
             if (ShouldShow(settings))
             {
-                var span = e.Tag.Owner.CreateElement("span");
-                span.ClassName = "removed-tag"; // styled red by the app's CSS (no inline style: it would be stripped)
-                span.TextContent = $"[REMOVED: {e.Tag.TagName}]";
-                e.Tag.Replace(span);            // replaces the whole node -> inner content dropped
+                // Show the markup itself instead of a "[REMOVED: X]" label: the whole tag, with its
+                // children, is HTML-encoded in place. Nothing can run, and the reader sees exactly
+                // what was rejected.
+                e.Tag.OuterHtml = e.Tag.OuterHtml.HtmlEncode();
                 e.Cancel = true;                // safe here: the node is already swapped out
             }
             // else: LogRemoved-only -> let the normal removal proceed (respects KeepChildNodes).

--- a/Tests/Olive.Tests/HtmlSanitizerTests.cs
+++ b/Tests/Olive.Tests/HtmlSanitizerTests.cs
@@ -388,17 +388,21 @@ namespace Olive.Tests
         }
 
         [Test]
-        public void HtmlSanitizerFactory_ShowRemoved_ReplacesRemovedTagWithRedSpan()
+        public void HtmlSanitizerFactory_ShowRemoved_ShowsTheRemovedTagAsEncodedText()
         {
             var settings = HtmlSanitizerFactory.Default;
             settings.ShowRemoved = true;
             settings.ShowRemovedWhen = () => true; // markers are off unless this allows them
             var sanitizer = HtmlSanitizerFactory.Create(settings);
 
-            var result = sanitizer.Sanitize("<div>Hi <script>alert(1)</script> Bye</div>");
+            var result = sanitizer.Sanitize("<div>Hi <script src=\"e.js\">alert(1)</script> Bye</div>");
 
-            Assert.That(result, Does.Contain("<span class=\"removed-tag\">[REMOVED: SCRIPT]</span>"));
-            Assert.That(result, Does.Not.Contain("alert(1)")); // inner content dropped
+            // The whole tag is shown, encoded, so the reader sees what was rejected...
+            // Quotes need no escaping in text, so they read normally; the angle brackets are gone.
+            result.ShouldEqual("<div>Hi &lt;script src=\"e.js\"&gt;alert(1)&lt;/script&gt; Bye</div>");
+
+            // ...and there is no live script tag left.
+            Assert.That(result, Does.Not.Contain("<script"));
         }
 
         [Test]
@@ -615,5 +619,33 @@ namespace Olive.Tests
 
             Assert.That(result, Does.Contain("data-removed-style=\"old | new\""));
         }
+
+        // ---- IsSafe: validating user input before it is saved ----
+        // No config section in the tests, so these run on the permissive Default policy.
+
+        [Test]
+        public void IsSafe_PlainContent_IsAccepted()
+        {
+            Assert.That(HtmlSanitizerFactory.IsSafe("<p>Hello <b>world</b>, 2 &lt; 3.</p>"), Is.True);
+            Assert.That(HtmlSanitizerFactory.IsSafe(""), Is.True);
+            Assert.That(HtmlSanitizerFactory.IsSafe(null), Is.True);
+        }
+
+        [Test]
+        public void IsSafe_UnsafeContent_IsRejected()
+        {
+            Assert.That(HtmlSanitizerFactory.IsSafe("<div>Hi <script>alert(1)</script></div>"), Is.False);
+            Assert.That(HtmlSanitizerFactory.IsSafe("<img src=\"a.jpg\" onerror=\"alert(1)\">"), Is.False);
+            Assert.That(HtmlSanitizerFactory.IsSafe("<a href=\"javascript:alert(1)\">click</a>"), Is.False);
+        }
+
+        [Test]
+        public void IsSafe_RewrittenButHarmlessMarkup_IsAlsoRejected()
+        {
+            // Nothing here is dangerous, but Sanitize() writes it back differently, so the exact
+            // comparison says no. Keep it in mind when choosing which fields to guard.
+            Assert.That(HtmlSanitizerFactory.IsSafe("<P CLASS='intro'>a<BR/>b</P>"), Is.False);
+        }
+
     }
 }


### PR DESCRIPTION
Increment version to 10.3.2. Add HtmlSanitizerFactory.IsSafe for input validation. Change ShowRemoved to encode and display removed tags instead of using a span label. Update and expand unit tests for new behaviors.