### PR TITLE
Show removed HTML tags as encoded text in sanitizer

### DIFF
--- a/Olive.Mvc/Olive.Mvc.csproj
+++ b/Olive.Mvc/Olive.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.3.3</Version>
+    <Version>10.3.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Olive.Mvc/Utilities/HtmlSanitizerFactory.cs
+++ b/Olive.Mvc/Utilities/HtmlSanitizerFactory.cs
@@ -255,15 +255,14 @@ namespace Olive.Mvc
             if (settings.LogRemoved)
                 LogRemoval("tag", e.Tag.TagName, e.Reason, e.Tag);
 
-            if (ShouldShow(settings))
-            {
-                // Show the markup itself instead of a "[REMOVED: X]" label: the whole tag, with its
-                // children, is HTML-encoded in place. Nothing can run, and the reader sees exactly
-                // what was rejected.
-                e.Tag.OuterHtml = e.Tag.OuterHtml.HtmlEncode();
-                e.Cancel = true;                // safe here: the node is already swapped out
-            }
-            // else: LogRemoved-only -> let the normal removal proceed (respects KeepChildNodes).
+            // The whole tag, with its children, is HTML-encoded in place. Nothing can run, and the
+            // reader sees exactly what was written.
+            // This is NOT gated by ShowRemoved/ShowRemovedWhen, unlike the attribute markers below.
+            // Those are a tester aid, but dropping a tag loses the author's own text: an unknown
+            // tag such as <risk label> simply vanishes from the page, and a stored answer then
+            // reads as if the writer never typed it.
+            e.Tag.OuterHtml = e.Tag.OuterHtml.HtmlEncode();
+            e.Cancel = true;                    // safe here: the node is already swapped out
         }
 
         /// <summary>Adds a value to an attribute, keeping whatever is already there, and returns the

--- a/Tests/Olive.Tests/HtmlSanitizerTests.cs
+++ b/Tests/Olive.Tests/HtmlSanitizerTests.cs
@@ -292,11 +292,13 @@ namespace Olive.Tests
         }
 
         [Test]
-        public void Raw_WithSanitizeTrue_RemovesScriptElementButKeepsChildText()
+        public void Raw_WithSanitizeTrue_ShowsTheScriptElementAsText()
         {
+            // KeepChildNodes used to leave the bare script body ("removed()") on the page. The
+            // whole tag is shown instead now, encoded, so the reader can see what it was.
             var result = GetHtml("<p>Hi</p><script>removed()</script>".Raw());
 
-            result.ShouldEqual("<p>Hi</p>removed()");
+            result.ShouldEqual("<p>Hi</p>&lt;script&gt;removed()&lt;/script&gt;");
         }
 
         [Test]
@@ -618,6 +620,22 @@ namespace Olive.Tests
                 .Sanitize("<img src=\"a.webp\" data-removed-style=\"old\" style=\"new\">");
 
             Assert.That(result, Does.Contain("data-removed-style=\"old | new\""));
+        }
+
+        [Test]
+        public void RemovedTag_IsShownEncoded_EvenWhenMarkersAreOff()
+        {
+            // Real stored answer: <risk label> is not a known tag. Dropping it took the writer's
+            // own text off the page, which is why this does not depend on ShowRemoved.
+            var input = "<p>Risk Assessment:</p><p><risk label></p><p>Follow-up Questions:</p>";
+
+            var result = GetHtml(input.Raw());
+
+            // AngleSharp writes the parsed element back in its normal form, so the attribute
+            // gains ="" and the tag is closed. The text is on the page either way.
+            Assert.That(result, Does.Contain("&lt;risk label=\"\"&gt;&lt;/risk&gt;"));
+            Assert.That(result, Does.Contain("Risk Assessment:"));
+            Assert.That(result, Does.Contain("Follow-up Questions:"));
         }
 
         // ---- IsSafe: validating user input before it is saved ----


### PR DESCRIPTION
Updated HtmlSanitizer to always display removed tags as HTML-encoded text, ensuring user input is visible even for unknown or unsafe tags. Adjusted related tests to reflect this behavior and incremented project version to 10.3.4. Added a new test to verify encoded output for unknown tags regardless of marker settings.