### PR TITLE
Refactor IsSafe to use removal counting, add SanitizeReport

### DIFF
--- a/Olive.Mvc/Olive.Mvc.csproj
+++ b/Olive.Mvc/Olive.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.3.4</Version>
+    <Version>10.3.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Olive.Mvc/Utilities/HtmlSanitizerFactory.cs
+++ b/Olive.Mvc/Utilities/HtmlSanitizerFactory.cs
@@ -109,14 +109,42 @@ namespace Olive.Mvc
         public static string Sanitize(string html) => Shared.Value.Sanitize(html);
 
         /// <summary>
-        /// True when <see cref="Sanitize(string)"/> gives back exactly this HTML, i.e. saving it
-        /// means the reader sees what the writer typed. Use it to reject input that the sanitizer
-        /// would change, instead of letting it be changed silently at render time.
-        /// <para>The test is an exact comparison, so a rewrite counts as well as a removal:
-        /// Sanitize() re-serializes the document, so <c>&lt;BR/&gt;</c> becomes <c>&lt;br&gt;</c>,
-        /// single quotes become double quotes, and an unclosed tag gets closed.</para>
+        /// True when <see cref="Sanitize(string)"/> would take nothing out of this HTML, i.e.
+        /// saving it means the reader sees what the writer typed. Use it to reject unsafe input at
+        /// save time, instead of letting the page drop it silently.
         /// </summary>
-        public static bool IsSafe(string html) => html.IsEmpty() || Sanitize(html) == html;
+        public static bool IsSafe(string html) => SanitizeReport(html) == 0;
+
+        /// <summary>
+        /// How many tags and attributes <see cref="Sanitize(string)"/> would remove from this HTML.
+        /// Zero means nothing would be taken out.
+        /// <para>It counts removals only, so markup that the sanitizer merely writes back in another
+        /// form does not count. Sanitize() re-serializes the document, so <c>&lt;BR/&gt;</c> becomes
+        /// <c>&lt;br&gt;</c> and single quotes become double quotes. Comparing the two strings would
+        /// report those as a problem; this does not.</para>
+        /// <para>It uses its own sanitizer, built from the same settings, because the counting
+        /// handlers belong to this one call while the shared instance serves every request.</para>
+        /// </summary>
+        public static int SanitizeReport(string html)
+        {
+            if (html.IsEmpty()) return 0;
+
+            // Reading Shared.Value is what binds the settings from config, so it must come first.
+            // It also means this check uses exactly the policy that Raw() will apply.
+            _ = Shared.Value;
+
+            var removed = 0;
+            var sanitizer = Create(SettingsInstance);
+
+            sanitizer.RemovingTag += (_, _) => removed++;
+
+            // Create() attached its own handler first, which cancels (keeps) an allowed aria-*.
+            sanitizer.RemovingAttribute += (_, e) => { if (!e.Cancel) removed++; };
+
+            sanitizer.Sanitize(html);
+
+            return removed;
+        }
 
         // Runs on the first Sanitize() call, when Context is ready. The config values are copied
         // INTO the existing SettingsInstance, so delegates already assigned in Startup survive.

--- a/Tests/Olive.Tests/HtmlSanitizerTests.cs
+++ b/Tests/Olive.Tests/HtmlSanitizerTests.cs
@@ -658,11 +658,23 @@ namespace Olive.Tests
         }
 
         [Test]
-        public void IsSafe_RewrittenButHarmlessMarkup_IsAlsoRejected()
+        public void IsSafe_RewrittenButHarmlessMarkup_IsAccepted()
         {
-            // Nothing here is dangerous, but Sanitize() writes it back differently, so the exact
-            // comparison says no. Keep it in mind when choosing which fields to guard.
-            Assert.That(HtmlSanitizerFactory.IsSafe("<P CLASS='intro'>a<BR/>b</P>"), Is.False);
+            // Sanitize() writes this back differently (lower case tag, double quotes, <br>), but it
+            // takes nothing out. The count is what decides, so the save is allowed.
+            const string html = "<P CLASS='intro'>a<BR/>b</P>";
+
+            Assert.That(HtmlSanitizerFactory.Sanitize(html), Is.Not.EqualTo(html));
+            Assert.That(HtmlSanitizerFactory.SanitizeReport(html), Is.EqualTo(0));
+            Assert.That(HtmlSanitizerFactory.IsSafe(html), Is.True);
+        }
+
+        [Test]
+        public void SanitizeReport_CountsEachRemoval()
+        {
+            HtmlSanitizerFactory.SanitizeReport("<p>clean</p>").ShouldEqual(0);
+            HtmlSanitizerFactory.SanitizeReport("<p><risk label></p>").ShouldEqual(1);
+            HtmlSanitizerFactory.SanitizeReport("<img src=\"a.jpg\" onerror=\"x()\" onclick=\"y()\">").ShouldEqual(2);
         }
 
     }


### PR DESCRIPTION
IsSafe now uses SanitizeReport to count actual tag/attribute removals, avoiding false negatives from harmless HTML rewrites. Added SanitizeReport method and updated XML docs. Unit tests revised to reflect new logic and verify removal counting.