### PR TITLE
Fix Include(...) loading with paged/partial queries

### DIFF
--- a/Olive.Entities.Data/Olive.Entities.Data.csproj
+++ b/Olive.Entities.Data/Olive.Entities.Data.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>10.4.3</Version>
+    <Version>10.4.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Olive.Entities.Data/QueryExecution/AssociationInclusion.cs
+++ b/Olive.Entities.Data/QueryExecution/AssociationInclusion.cs
@@ -22,31 +22,30 @@ namespace Olive.Entities.Data
 
         public async Task LoadAssociations(DatabaseQuery query, IEnumerable<IEntity> mainObjects)
         {
-            var associatedObjects = LoadTheAssociatedObjects(query);
-
-            var groupedObjects = GroupTheMainObjects(mainObjects);
-
             var cachedField = query.EntityType.GetField("cached" + Association.Name,
                 BindingFlags.NonPublic | BindingFlags.Instance);
 
-            if (cachedField != null)
-                foreach (var associatedObject in await associatedObjects)
-                {
-                    var group = groupedObjects.GetOrDefault(associatedObject.GetId());
-                    if (group == null)
-                    {
-                        if (query.PageSize.HasValue) continue;
+            if (cachedField == null) return;
 
-                        throw new Exception($@"Database include binding failed.
+            var groupedObjects = GroupTheMainObjects(mainObjects);
+
+            foreach (var associatedObject in await LoadTheAssociatedObjects(query, groupedObjects.Keys))
+            {
+                var group = groupedObjects.GetOrDefault(associatedObject.GetId());
+                if (group == null)
+                {
+                    if (query.PageSize.HasValue) continue;
+
+                    throw new Exception($@"Database include binding failed.
 The loaded associated {associatedObject.GetType().Name} with the id {associatedObject.GetId()},
 is not referenced by any {Association.DeclaringType.Name} object!
 Hint: All associated {Association.Name} Ids are:
 {groupedObjects.Select(x => x.Key).ToLinesString()}");
-                    }
-
-                    foreach (var mainEntity in group)
-                        BindToCachedField(cachedField, associatedObject, mainEntity);
                 }
+
+                foreach (var mainEntity in group)
+                    BindToCachedField(cachedField, associatedObject, mainEntity);
+            }
         }
 
         void BindToCachedField(FieldInfo cachedField, IEntity associatedObject, IEntity mainEntity)
@@ -69,15 +68,45 @@ Hint: All associated {Association.Name} Ids are:
                 .ToDictionary(i => i.Key, i => i.ToArray());
         }
 
-        Task<IEntity[]> LoadTheAssociatedObjects(DatabaseQuery query)
+        Task<IEntity[]> LoadTheAssociatedObjects(DatabaseQuery query, ICollection<object> associatedIds)
         {
             var nestedQuery = Context.Current.Database().Of(Association.PropertyType);
             var provider = ((DatabaseQuery)nestedQuery).Provider;
 
+            ICriterion criterion = null;
+
+            if (query.TakeTop.HasValue || query.PageSize.HasValue)
+            {
+                // The main query returned only a window of its matching rows (Top(), FirstOrDefault() or paging).
+                // Running it again as a sub-query can return a different window, because without a fully
+                // deterministic sort the database is free to pick any rows for TOP / OFFSET.
+                // That would load the associated objects of the wrong rows, so filter on the loaded ids instead.
+                if (associatedIds.None()) return Task.FromResult(new IEntity[0]);
+
+                criterion = CreateIdsCriterion(associatedIds);
+            }
+
+            criterion ??= provider.GetAssociationInclusionCriteria(query, Association);
+
             return nestedQuery
-                       .Where(provider.GetAssociationInclusionCriteria(query, Association))
+                       .Where(criterion)
                        .Include(IncludedNestedAssociations)
                        .GetList();
+        }
+
+        /// <summary>
+        /// Creates an "ID IN (...)" criterion for the specified ids.
+        /// It returns null for an unsupported ID type, in which case the caller should fall back to a sub-query.
+        /// </summary>
+        static ICriterion CreateIdsCriterion(IEnumerable<object> ids)
+        {
+            var items = ids.ExceptNull().ToArray();
+
+            if (items.All(x => x is Guid)) return new Criterion("ID", FilterFunction.In, items.Cast<Guid>());
+            if (items.All(x => x is int)) return new Criterion("ID", FilterFunction.In, items.Cast<int>());
+            if (items.All(x => x is string)) return new Criterion("ID", FilterFunction.In, items.Cast<string>());
+
+            return null;
         }
     }
 }

--- a/docs/ChangeLog.md
+++ b/docs/ChangeLog.md
@@ -1,6 +1,9 @@
 
 # Olive compatibility change log
 
+## 11 Sep 2026
+- Fixed eager loading (`Include(...)`) on queries that return only part of their matching rows: `FirstOrDefault()`, `Top(n)` and paging. The associated objects were loaded by running the main query again as a sub-query, and since `TOP` / `OFFSET` without a fully deterministic sort may return a different set of rows each time, the wrong associations were loaded. The association was then left unbound (so each one was lazy-loaded one by one on first access), or the load threw "Database include binding failed". Such queries now filter the associated objects on the ids of the rows actually loaded. No code changes required. `Olive.Entities.Data` bumped to `10.4.4`.
+
 ## 4 Sep 2026
 - `Any()`/`None()` on `IDatabaseQuery` (and the `Database.Any<T>()`/`Any<T>(criteria)`/`None<T>(...)` convenience methods) now generate a `SELECT TOP 1 ...` existence probe instead of `SELECT Count(...) > 0`, so SQL Server/MySQL/PostgreSQL/SQLite can stop at the first matching row instead of aggregating over every match. Also fixed row parsing (`GetList()`/`Get()`) to stop calling `IDataReader.GetSchemaTable()` once per row (and once per base/derived table of that row) — the reader's column set is now read once per query execution and reused, which was a real cost on large result sets, especially combined with `Select(columns)` narrowing. Both are internal/behavioural improvements; no code changes required. `Olive.Entities.Data` bumped to `10.4.3`.
 


### PR DESCRIPTION
Fixed eager loading of associations for queries returning only a subset of rows (e.g., FirstOrDefault(), Top(n), paging). Associated objects are now filtered by the actual loaded IDs, preventing mismatches and unbound associations. No consumer code changes required. Version bumped to 10.4.4.