### PR TITLE
Add KeepAttributes config to HTML sanitizer for exceptions

### DIFF
--- a/Olive.Mvc/Olive.Mvc.csproj
+++ b/Olive.Mvc/Olive.Mvc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.3.5</Version>
+    <Version>10.3.6</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Olive.Mvc/Utilities/HtmlSanitizerFactory.cs
+++ b/Olive.Mvc/Utilities/HtmlSanitizerFactory.cs
@@ -1,4 +1,4 @@
-using AngleSharp.Dom;
+﻿using AngleSharp.Dom;
 using Ganss.Xss;
 using Microsoft.Extensions.Configuration;
 using System;
@@ -35,6 +35,20 @@ namespace Olive.Mvc
         /// <summary>The only hosts an iframe may load (~ the CSP "frame-src" directive). Subdomains included.</summary>
         public string[] AllowedFrameDomains { get; set; }
 
+        /// <summary>
+        /// Exceptions to the attribute rules. An attribute that the sanitizer is about to remove is
+        /// kept when one of these matches it, so a new case can be allowed from config instead of
+        /// from code.
+        /// <para>The case it was written for: a CKEditor upload puts the picture straight into the
+        /// markup as <c>&lt;img src="data:image/png;base64,..."&gt;</c>. "data" is not an allowed
+        /// scheme, so the src was dropped and the picture disappeared. One entry with tag "img",
+        /// attribute "src" and value "data:image/" brings it back.</para>
+        /// <para>Whatever is configured, an exception can never keep an <c>on*</c> handler, nor a
+        /// value holding <c>javascript:</c> or <c>vbscript:</c>, however it is spelled. See
+        /// <see cref="HtmlSanitizerFactory.IsKept"/>.</para>
+        /// </summary>
+        public KeptAttribute[] KeepAttributes { get; set; }
+
         /// <summary>Allow inert data-* attributes.</summary>
         public bool AllowDataAttributes { get; set; }
 
@@ -58,6 +72,21 @@ namespace Olive.Mvc
         /// in Startup. A marker is shown only when ShowRemoved is true AND this returns true;
         /// null (not set, or no signed-in user) hides the markers.</summary>
         public Func<bool?> ShowRemovedWhen { get; set; }
+    }
+
+    /// <summary>One entry of <see cref="HtmlSanitizerSettings.KeepAttributes"/>: an attribute the
+    /// sanitizer must keep even though its own rules would remove it.</summary>
+    public sealed class KeptAttribute
+    {
+        /// <summary>The element this applies to, e.g. "img". Empty or "*" means any element.</summary>
+        public string Tag { get; set; }
+
+        /// <summary>The attribute name, e.g. "src". Required; an entry without it is ignored.</summary>
+        public string Attribute { get; set; }
+
+        /// <summary>The value must start with this, e.g. "data:image/". Empty means any value,
+        /// so the attribute is always kept on that element.</summary>
+        public string ValueStartsWith { get; set; }
     }
 
     /// <summary>
@@ -163,6 +192,7 @@ namespace Olive.Mvc
             onto.RemoveAttributes = source.RemoveAttributes;
             onto.UriAttributes = source.UriAttributes;
             onto.AllowedFrameDomains = source.AllowedFrameDomains;
+            onto.KeepAttributes = source.KeepAttributes;
             onto.AllowDataAttributes = source.AllowDataAttributes;
             onto.AllowAriaAttributes = source.AllowAriaAttributes;
             onto.KeepChildNodes = source.KeepChildNodes;
@@ -254,6 +284,14 @@ namespace Olive.Mvc
                 return;
             }
 
+            // A configured exception, e.g. the data:image/... src of a picture pasted into CKEditor.
+            // Cancel keeps the attribute with its original value, so nothing is logged or marked.
+            if (IsKept(e, settings.KeepAttributes))
+            {
+                e.Cancel = true;
+                return;
+            }
+
             if (settings.LogRemoved)
                 LogRemoval("attribute", $"{name}=\"{e.Attribute.Value}\"", e.Reason, e.Tag);
 
@@ -339,6 +377,49 @@ namespace Olive.Mvc
             domains.Any(domain =>
                 host.Equals(domain, StringComparison.OrdinalIgnoreCase) ||
                 host.EndsWith("." + domain, StringComparison.OrdinalIgnoreCase));
+
+        /// <summary>
+        /// Whether a configured exception says to keep this attribute
+        /// (see <see cref="HtmlSanitizerSettings.KeepAttributes"/>).
+        /// <para>Two things are refused whatever the config says, because keeping them would be a
+        /// live XSS hole and no picture or layout needs them: an <c>on*</c> handler, and a value
+        /// containing <c>javascript:</c> or <c>vbscript:</c>, including the spellings that hide a
+        /// control character inside the scheme. So a wrong config entry can make the page uglier,
+        /// never unsafe.</para>
+        /// <para>It cannot undo everything, though: an entry naming a URL attribute such as
+        /// <c>iframe</c>/<c>src</c> also switches off the
+        /// <see cref="HtmlSanitizerSettings.AllowedFrameDomains"/> check for it, and
+        /// <c>data:image/</c> is only inert on an <c>img</c>, not on an <c>object</c> or
+        /// <c>embed</c>, where an SVG can run script. Name the tag, and keep the list short.</para>
+        /// </summary>
+        internal static bool IsKept(RemovingAttributeEventArgs e, KeptAttribute[] exceptions)
+        {
+            if (exceptions.None()) return false;
+
+            var name = e.Attribute.Name;
+            if (name.StartsWith("on", StringComparison.OrdinalIgnoreCase)) return false;
+
+            var value = e.Attribute.Value.OrEmpty();
+
+            // A browser ignores TAB, CR, LF and the other control characters that sit inside a URL
+            // scheme, so "java&#9;script:alert(1)" still runs. Searching the raw value would miss
+            // that, so the scheme check runs on a copy with those characters taken out.
+            var scannable = new string(value.Where(c => c > 31 && c != 127).ToArray());
+            if (scannable.Contains("javascript:", StringComparison.OrdinalIgnoreCase)) return false;
+            if (scannable.Contains("vbscript:", StringComparison.OrdinalIgnoreCase)) return false;
+
+            var tag = e.Tag?.NodeName.OrEmpty();
+
+            // ValueStartsWith is matched on the RAW value on purpose. A value that only matches
+            // after cleaning is not the plain case these exceptions are for, so it stays removed.
+            return exceptions.Any(x =>
+                x != null &&
+                x.Attribute.HasValue() &&
+                x.Attribute.Equals(name, StringComparison.OrdinalIgnoreCase) &&
+                (x.Tag.IsEmpty() || x.Tag == "*" || x.Tag.Equals(tag, StringComparison.OrdinalIgnoreCase)) &&
+                (x.ValueStartsWith.IsEmpty() ||
+                 value.StartsWith(x.ValueStartsWith, StringComparison.OrdinalIgnoreCase)));
+        }
 
         /// <summary>An attribute name safe to embed into a data-removed-{name} attribute.</summary>
         static bool IsSafeAttrName(string name) =>

--- a/Tests/Olive.Tests/HtmlSanitizerTests.cs
+++ b/Tests/Olive.Tests/HtmlSanitizerTests.cs
@@ -1,4 +1,4 @@
-using Ganss.Xss;
+﻿using Ganss.Xss;
 using Microsoft.AspNetCore.Html;
 using NUnit.Framework;
 using Olive.Mvc;
@@ -636,6 +636,149 @@ namespace Olive.Tests
             Assert.That(result, Does.Contain("&lt;risk label=\"\"&gt;&lt;/risk&gt;"));
             Assert.That(result, Does.Contain("Risk Assessment:"));
             Assert.That(result, Does.Contain("Follow-up Questions:"));
+        }
+
+        // ---- KeepAttributes: config exceptions to the attribute rules ----
+
+        static HtmlSanitizer BuildWithKeptDataImages() =>
+            HtmlSanitizerFactory.Create(new HtmlSanitizerSettings
+            {
+                AllowedSchemes = new[] { "http", "https", "mailto", "tel" },
+                AllowAttributes = new[] { "id", "class" },
+                KeepChildNodes = true,
+                KeepAttributes = new[]
+                {
+                    new KeptAttribute { Tag = "img", Attribute = "src", ValueStartsWith = "data:image/" }
+                }
+            });
+
+        [Test]
+        public void KeepAttributes_KeepsAPictureUploadedInTheEditor()
+        {
+            // CKEditor puts an uploaded picture straight into the markup as a data URI.
+            var result = BuildWithKeptDataImages()
+                .Sanitize("<p><img src=\"data:image/png;base64,iVBORw0KGgo=\" alt=\"chart\"></p>");
+
+            Assert.That(result, Does.Contain("src=\"data:image/png;base64,iVBORw0KGgo=\""));
+            Assert.That(result, Does.Contain("alt=\"chart\""));
+        }
+
+        [Test]
+        public void KeepAttributes_SavingSuchAnAnswerIsAllowed()
+        {
+            // The same rule decides IsSafe, so the student can save the answer that holds the picture.
+            var sanitizer = BuildWithKeptDataImages();
+            const string html = "<p><img src=\"data:image/png;base64,iVBORw0KGgo=\"></p>";
+
+            sanitizer.Sanitize(html).ShouldEqual(html);
+        }
+
+        [Test]
+        public void KeepAttributes_KeepsAPicturePastedFromOffice()
+        {
+            // Office 365 pastes a picture as a blob: URL, which is another scheme the sanitizer
+            // does not allow. A second entry covers it, with no code change.
+            var sanitizer = HtmlSanitizerFactory.Create(new HtmlSanitizerSettings
+            {
+                AllowedSchemes = new[] { "http", "https" },
+                KeepAttributes = new[]
+                {
+                    new KeptAttribute { Tag = "img", Attribute = "src", ValueStartsWith = "blob:" }
+                }
+            });
+
+            var result = sanitizer.Sanitize(
+                "<img alt=\"training data workflow\" src=\"blob:https://m365.cloud.microsoft/e4ae3e22\">");
+
+            Assert.That(result, Does.Contain("src=\"blob:https://m365.cloud.microsoft/e4ae3e22\""));
+            Assert.That(result, Does.Contain("alt=\"training data workflow\""));
+        }
+
+        [Test]
+        public void KeepAttributes_DoesNotApplyToAnotherTagOrAnotherValue()
+        {
+            var sanitizer = BuildWithKeptDataImages();
+
+            // The rule names img, so an anchor does not get it.
+            Assert.That(sanitizer.Sanitize("<a href=\"data:image/png;base64,AAA\">x</a>"),
+                Does.Not.Contain("data:"));
+
+            // ...and a data URI that is not a picture does not match "data:image/".
+            Assert.That(sanitizer.Sanitize("<img src=\"data:text/html;base64,AAA\">"),
+                Does.Not.Contain("data:"));
+        }
+
+        [Test]
+        public void KeepAttributes_CanNeverKeepAScriptHook()
+        {
+            // A wrong entry tries to allow onerror and a javascript: link. Both are refused.
+            var sanitizer = HtmlSanitizerFactory.Create(new HtmlSanitizerSettings
+            {
+                AllowedSchemes = new[] { "http", "https" },
+                KeepAttributes = new[]
+                {
+                    new KeptAttribute { Attribute = "onerror" },
+                    new KeptAttribute { Tag = "a", Attribute = "href" }
+                }
+            });
+
+            var result = sanitizer.Sanitize("<img src=\"a.jpg\" onerror=\"alert(1)\">" +
+                                            "<a href=\"javascript:alert(1)\">x</a>");
+
+            Assert.That(result, Does.Not.Contain("onerror"));
+            Assert.That(result, Does.Not.Contain("javascript:"));
+        }
+
+        [Test]
+        public void KeepAttributes_CanNeverKeepAScriptHookHiddenInTheScheme()
+        {
+            // A browser ignores a TAB or a line break sitting inside the scheme, so
+            // "java&#9;script:alert(1)" still runs. A plain search for "javascript:" misses it.
+            var sanitizer = HtmlSanitizerFactory.Create(new HtmlSanitizerSettings
+            {
+                AllowedSchemes = new[] { "http", "https" },
+                KeepAttributes = new[] { new KeptAttribute { Tag = "a", Attribute = "href" } }
+            });
+
+            var attacks = new[]
+            {
+                "java&#9;script:alert(1)",      // tab
+                "java&#10;script:alert(1)",     // line feed
+                "java&#13;script:alert(1)",     // carriage return
+                "j&#9;a&#10;v&#13;ascript:alert(1)",
+                "vb&#9;script:alert(1)",
+                "&#1;javascript:alert(1)"       // a control character in front
+            };
+
+            foreach (var attack in attacks)
+            {
+                var result = sanitizer.Sanitize($"<a href=\"{attack}\">x</a>");
+
+                Assert.That(result, Does.Not.Contain("href"), attack);
+                Assert.That(result, Does.Not.Contain("alert"), attack);
+            }
+        }
+
+        [Test]
+        public void KeepAttributes_BindsFromTheConfigSection()
+        {
+            // The shape an app writes in appsettings.json, bound the same way the factory binds it.
+            const string json = @"{ ""Html"": { ""Sanitizer"": {
+                ""KeepAttributes"": [ { ""Tag"": ""img"", ""Attribute"": ""src"", ""ValueStartsWith"": ""data:image/"" } ]
+            } } }";
+
+            var config = Microsoft.Extensions.Configuration.JsonConfigurationExtensions
+                .AddJsonStream(new Microsoft.Extensions.Configuration.ConfigurationBuilder(),
+                               new MemoryStream(System.Text.Encoding.UTF8.GetBytes(json)))
+                .Build();
+
+            var settings = Microsoft.Extensions.Configuration.ConfigurationBinder
+                .Get<HtmlSanitizerSettings>(config.GetSection("Html:Sanitizer"));
+
+            settings.KeepAttributes.Length.ShouldEqual(1);
+            settings.KeepAttributes[0].Tag.ShouldEqual("img");
+            settings.KeepAttributes[0].Attribute.ShouldEqual("src");
+            settings.KeepAttributes[0].ValueStartsWith.ShouldEqual("data:image/");
         }
 
         // ---- IsSafe: validating user input before it is saved ----


### PR DESCRIPTION
Introduce KeepAttributes to allow specific attributes (e.g., img src="data:image/...") to be preserved by the sanitizer. Add KeptAttribute class for defining exceptions. Update sanitizer logic to honor these exceptions while maintaining security against event handlers and script URIs. Add comprehensive tests and increment version to 10.3.6.